### PR TITLE
Feature/#17 diary crud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 # Secret configs
 src/main/resources/application-*.yml
+gradle.properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
@@ -37,6 +38,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,13 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    //oauth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //solapi
+    implementation 'com.solapi:sdk:1.0.3'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.flywaydb.flyway' version '11.7.2'  // Flyway 플러그인 추가
 }
 
 group = 'com.beanspot'
@@ -45,4 +46,12 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+flyway {
+    url = project.findProperty("flyway.url")
+    user = project.findProperty("flyway.user")
+    password = project.findProperty("flyway.password")
+    locations = ['classpath:db/migration']
+    baselineOnMigrate = true
 }

--- a/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
@@ -6,7 +6,27 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     CALENDAR_SCHEDULE_NOT_FOUND(11001, HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
     CALENDAR_INVALID_REPEAT_RULE(11002, HttpStatus.BAD_REQUEST, "유효하지 않은 반복 주기입니다."),
-    INTERNAL_SERVER_ERROR(90000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(90000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+
+    // ==================== Auth (21xxx) ====================
+    AUTH_LOGIN_REQUIRED(21001, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    AUTH_INVALID_CREDENTIALS(21002, HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_EMAIL_NOT_FOUND(21003, HttpStatus.UNAUTHORIZED, "이메일이 존재하지 않습니다."),
+    AUTH_ACCOUNT_LOCKED(21003, HttpStatus.FORBIDDEN, "계정이 잠겼습니다. 관리자에게 문의하세요."),
+    AUTH_TOKEN_EXPIRED(21004, HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다."),
+    AUTH_TOKEN_INVALID(21005, HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다."),
+    AUTH_ACCESS_DENIED(21006, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    AUTH_USERID_ALREADY_EXISTS(21101, HttpStatus.CONFLICT, "이미 사용 중인 사용자 아이디입니다."),
+
+    AUTH_EMAIL_ALREADY_EXISTS(21102, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    AUTH_NICKNAME_ALREADY_EXISTS(21103, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    AUTH_PASSWORD_WEAK(21103, HttpStatus.BAD_REQUEST, "비밀번호가 보안 규칙에 맞지 않습니다."),
+    AUTH_PASSWORD_MISMATCH(21104, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+    AUTH_EMAIL_NOT_VERIFIED(21201, HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
+    AUTH_VERIFICATION_CODE_INVALID(21202, HttpStatus.BAD_REQUEST, "인증 코드가 유효하지 않습니다."),
+    AUTH_VERIFICATION_CODE_EXPIRED(21203, HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다.");
+    ;
 
     private final int code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
@@ -16,12 +16,14 @@ public enum ErrorCode {
     AUTH_TOKEN_EXPIRED(21004, HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다."),
     AUTH_TOKEN_INVALID(21005, HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다."),
     AUTH_ACCESS_DENIED(21006, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    AUTH_USERID_ALREADY_EXISTS(21101, HttpStatus.CONFLICT, "이미 사용 중인 사용자 아이디입니다."),
+    AUTH_SOCIAL_ID_NOT_FOUND(21007, HttpStatus.UNAUTHORIZED, "해당 소셜아이디로 가입된 정보가 없습니다.."),
 
+    AUTH_USERID_ALREADY_EXISTS(21101, HttpStatus.CONFLICT, "이미 사용 중인 사용자 아이디입니다."),
     AUTH_EMAIL_ALREADY_EXISTS(21102, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     AUTH_NICKNAME_ALREADY_EXISTS(21103, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
-    AUTH_PASSWORD_WEAK(21103, HttpStatus.BAD_REQUEST, "비밀번호가 보안 규칙에 맞지 않습니다."),
-    AUTH_PASSWORD_MISMATCH(21104, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    AUTH_PASSWORD_WEAK(21104, HttpStatus.BAD_REQUEST, "비밀번호가 보안 규칙에 맞지 않습니다."),
+    AUTH_PASSWORD_MISMATCH(21105, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    AUTH_SOCIAL_ID_ALREADY_EXISTS(21106, HttpStatus.CONFLICT, "이미 사용 중인 소셜 아이디입니다."),
 
     AUTH_EMAIL_NOT_VERIFIED(21201, HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     AUTH_VERIFICATION_CODE_INVALID(21202, HttpStatus.BAD_REQUEST, "인증 코드가 유효하지 않습니다."),

--- a/src/main/java/com/beanspot/backend/config/WebMvcConfig.java
+++ b/src/main/java/com/beanspot/backend/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.beanspot.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    private  final long MAX_AGE_SECS = 3600;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").
+                allowedOrigins("http://127.0.0.1:8081", "http://localhost:8081")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(MAX_AGE_SECS);
+    }
+}

--- a/src/main/java/com/beanspot/backend/controller/AdminController.java
+++ b/src/main/java/com/beanspot/backend/controller/AdminController.java
@@ -1,0 +1,69 @@
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.dto.admin.NoticeRequestDto;
+import com.beanspot.backend.dto.admin.AnnouncementRequestDto;
+import com.beanspot.backend.service.NoticeService;
+import com.beanspot.backend.service.AnnouncementService;
+import com.beanspot.backend.service.AdminReportService;
+import com.beanspot.backend.security.CurrentUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize; // 추가
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')") // ⭐ 클래스 레벨에 추가: 관리자 권한이 없으면 이 컨트롤러 자체에 접근 불가
+public class AdminController {
+
+    private final NoticeService noticeService;
+    private final AnnouncementService announcementService;
+    private final AdminReportService adminReportService;
+
+    /**
+     * 1. 공지사항 등록 API
+     * POST /api/admin/notices
+     */
+    @PostMapping("/notices")
+    public ResponseEntity<Long> createNotice(
+            @CurrentUserId Long adminId,
+            @RequestBody NoticeRequestDto dto) {
+
+        Long noticeId = noticeService.createNotice(adminId, dto);
+        // 생성(Post) 성공 시 201 Created 상태 코드를 권장합니다.
+        return ResponseEntity.status(HttpStatus.CREATED).body(noticeId);
+    }
+
+    /**
+     * 2. 공고 관리(Announcement) API
+     * POST /api/admin/announcements
+     * 피그마 3단계(기본/상세/일정) 데이터를 한 번에 처리합니다.
+     */
+    @PostMapping("/announcements")
+    public ResponseEntity<Long> createAnnouncement(
+            @CurrentUserId Long adminId,
+            @RequestBody AnnouncementRequestDto dto) {
+
+        Long announcementId = announcementService.createAnnouncement(adminId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(announcementId);
+    }
+
+    /**
+     * 3. 신고 관리(Report) API
+     * PATCH /api/admin/reports/{reportId}/complete
+     */
+    @PatchMapping("/reports/{reportId}/complete")
+    public ResponseEntity<Map<String, Object>> completeReport(@PathVariable Long reportId) {
+        adminReportService.updateReportStatus(reportId);
+
+        // 메시지와 ID를 함께 반환하여 프론트엔드 처리를 돕습니다.
+        return ResponseEntity.ok(Map.of(
+                "message", "신고 처리가 완료되었습니다.",
+                "reportId", reportId
+        ));
+    }
+}

--- a/src/main/java/com/beanspot/backend/controller/AdminController.java
+++ b/src/main/java/com/beanspot/backend/controller/AdminController.java
@@ -48,8 +48,9 @@ public class AdminController {
             @CurrentUserId Long adminId,
             @RequestBody AnnouncementRequestDto dto) {
 
-        Long announcementId = announcementService.createAnnouncement(adminId, dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(announcementId);
+        // 순서 주의: 서비스 정의에 따라 (dto, adminId)로 호출
+        Long announcementId = announcementService.createAnnouncement(dto, adminId);
+        return ResponseEntity.ok(announcementId);
     }
 
     /**

--- a/src/main/java/com/beanspot/backend/controller/AuthController.java
+++ b/src/main/java/com/beanspot/backend/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.beanspot.backend.controller;
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
 import com.beanspot.backend.common.response.ApiResponse;
+import com.beanspot.backend.dto.auth.CheckNicknameResponseDTO;
 import com.beanspot.backend.dto.auth.LoginUserDTO;
 import com.beanspot.backend.dto.auth.SignUpSocialUserDTO;
 import com.beanspot.backend.dto.auth.SignUpUserDTO;
@@ -82,6 +83,20 @@ public class AuthController {
 
         return ApiResponse.ok(responseUserDTO);
 
+    }
+
+    @GetMapping("/check-nickname")
+    public ApiResponse<?> checkNickname(@RequestParam String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+        String message = isAvailable ?
+                "사용 가능한 닉네임입니다." :
+                "이미 사용 중인 닉네임입니다.";
+        CheckNicknameResponseDTO responseDTO = CheckNicknameResponseDTO.builder()
+                                                    .available(isAvailable)
+                                                    .nickname(nickname)
+                                                    .message(message)
+                                                    .build();
+        return ApiResponse.ok(responseDTO);
     }
 
 }

--- a/src/main/java/com/beanspot/backend/controller/AuthController.java
+++ b/src/main/java/com/beanspot/backend/controller/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
     public ApiResponse<?>  login(@RequestBody LoginUserDTO.Req userDTO) {
 
         User user = userService.getByCredential(
-                userDTO.getEmail(),
+                userDTO.getUserId(),
                 userDTO.getPassword(),
                 passwordEncoder
         );
@@ -62,7 +62,7 @@ public class AuthController {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .nickname(user.getNickname())
-                .userId(user.getId())
+                .id(user.getId())
                 .build();
 
         return ApiResponse.ok(reponseUserDTO);

--- a/src/main/java/com/beanspot/backend/controller/AuthController.java
+++ b/src/main/java/com/beanspot/backend/controller/AuthController.java
@@ -1,0 +1,72 @@
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.common.response.ApiResponse;
+import com.beanspot.backend.dto.auth.LoginUserDTO;
+import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.entity.User;
+import com.beanspot.backend.security.TokenProvider;
+import com.beanspot.backend.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name="인증 API", description = "회원가입 및 로그인 관련 API입니다.")
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @Autowired
+    private UserService userService;
+
+
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @PostMapping("/signup")
+    public ApiResponse<?> signup(@RequestBody SignUpUserDTO.Req userDTO) {
+
+        if (userDTO == null || userDTO.getPassword() == null) {
+            throw new RuntimeException("Invalid password value.");
+        }
+        SignUpUserDTO.Res responseUserDTO = userService.createUser(userDTO);
+        return ApiResponse.ok(responseUserDTO);
+
+    }
+
+
+    @PostMapping("/login")
+    public ApiResponse<?>  login(@RequestBody LoginUserDTO.Req userDTO) {
+
+        User user = userService.getByCredential(
+                userDTO.getEmail(),
+                userDTO.getPassword(),
+                passwordEncoder
+        );
+
+        // TODO 이메일 인증 체크
+
+        final String accessToken = tokenProvider.createAccessToken(user);
+        final String refreshToken = tokenProvider.createRefreshToken(user);
+
+
+
+        final LoginUserDTO.Res reponseUserDTO = LoginUserDTO.Res.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .nickname(user.getNickname())
+                .userId(user.getId())
+                .build();
+
+        return ApiResponse.ok(reponseUserDTO);
+
+    }
+
+}

--- a/src/main/java/com/beanspot/backend/controller/CalendarController.java
+++ b/src/main/java/com/beanspot/backend/controller/CalendarController.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.controller;public class CalendarController {
+}

--- a/src/main/java/com/beanspot/backend/controller/DiaryController.java
+++ b/src/main/java/com/beanspot/backend/controller/DiaryController.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.controller;public class DiaryController {
+}

--- a/src/main/java/com/beanspot/backend/controller/DiaryController.java
+++ b/src/main/java/com/beanspot/backend/controller/DiaryController.java
@@ -1,2 +1,69 @@
-package com.beanspot.backend.controller;public class DiaryController {
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.dto.user.DiaryRequestDto;
+import com.beanspot.backend.dto.user.DiaryResponseDto;
+import com.beanspot.backend.security.CurrentUser;
+import com.beanspot.backend.security.UserPrincipal;
+import com.beanspot.backend.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Diary", description = "일기 관련 API")
+@RestController
+@RequestMapping("/api/v1/diaries") // 명세서 규격에 맞춰 경로 수정
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @Operation(summary = "일기 작성", description = "새로운 일기를 작성합니다.")
+    @PostMapping
+    public ResponseEntity<Long> create(@CurrentUser UserPrincipal userPrincipal,
+                                       @RequestBody DiaryRequestDto dto) {
+        Long diaryId = diaryService.saveDiary(userPrincipal.getId(), dto);
+        return ResponseEntity.ok(diaryId);
+    }
+
+    @Operation(summary = "월별 일기 목록 조회", description = "특정 연도와 월의 일기 목록을 가져옵니다.")
+    @GetMapping
+    public ResponseEntity<List<DiaryResponseDto>> getMonthlyDiaries(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam int year,
+            @RequestParam int month) {
+        // 명세서: GET /api/v1/diaries?year=2025&month=12
+        List<DiaryResponseDto> diaries = diaryService.getMonthlyDiaries(userPrincipal.getId(), year, month);
+        return ResponseEntity.ok(diaries);
+    }
+
+    @Operation(summary = "일기 상세 조회", description = "특정 ID의 일기 상세 내용을 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<DiaryResponseDto> getDetail(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        // 명세서: GET /api/v1/diaries/{diaryId}
+        DiaryResponseDto diary = diaryService.getDiaryDetail(userPrincipal.getId(), id);
+        return ResponseEntity.ok(diary);
+    }
+
+    @Operation(summary = "일기 수정", description = "기존에 작성한 일기를 수정합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@CurrentUser UserPrincipal userPrincipal,
+                                       @PathVariable Long id,
+                                       @RequestBody DiaryRequestDto dto) {
+        diaryService.updateDiary(userPrincipal.getId(), id, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@CurrentUser UserPrincipal userPrincipal,
+                                       @PathVariable Long id) {
+        diaryService.deleteDiary(userPrincipal.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/beanspot/backend/controller/FeedbackController.java
+++ b/src/main/java/com/beanspot/backend/controller/FeedbackController.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.controller;public class FeedbackController {
+}

--- a/src/main/java/com/beanspot/backend/controller/TodoController.java
+++ b/src/main/java/com/beanspot/backend/controller/TodoController.java
@@ -1,0 +1,65 @@
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.dto.user.TodoRequestDto;
+import com.beanspot.backend.dto.user.TodoResponseDto;
+import com.beanspot.backend.security.CurrentUser;
+import com.beanspot.backend.security.UserPrincipal;
+import com.beanspot.backend.service.TodoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Todo", description = "투두리스트 관련 API")
+@RestController
+@RequestMapping("/api/v1/todos") // 명세서 규격 경로
+@RequiredArgsConstructor
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @Operation(summary = "일별 투두 조회", description = "특정 날짜의 투두 리스트를 가져옵니다.")
+    @GetMapping
+    public ResponseEntity<List<TodoResponseDto>> getDailyTodos(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        // 명세서: GET /api/v1/todos?date=2025-12-19
+        List<TodoResponseDto> todos = todoService.getDailyTodos(userPrincipal.getId(), date);
+        return ResponseEntity.ok(todos);
+    }
+
+    @Operation(summary = "투두 추가", description = "새로운 할 일을 추가합니다.")
+    @PostMapping
+    public ResponseEntity<Long> addTodo(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestBody TodoRequestDto dto) {
+        // 명세서: POST /api/v1/todos
+        Long todoId = todoService.addTodo(userPrincipal.getId(), dto);
+        return ResponseEntity.ok(todoId);
+    }
+
+    @Operation(summary = "투두 상태 변경", description = "할 일의 완료 여부를 토글합니다.")
+    @PatchMapping("/{todoId}/status")
+    public ResponseEntity<Void> toggleStatus(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long todoId) {
+        // 명세서: PATCH /api/v1/todos/{todoId}/status
+        todoService.toggleStatus(userPrincipal.getId(), todoId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "투두 삭제", description = "할 일을 삭제합니다.")
+    @DeleteMapping("/{todoId}")
+    public ResponseEntity<Void> deleteTodo(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long todoId) {
+        // 명세서: DELETE /api/v1/todos/{todoId}
+        todoService.deleteTodo(userPrincipal.getId(), todoId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/beanspot/backend/controller/UserController.java
+++ b/src/main/java/com/beanspot/backend/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.common.response.ApiResponse;
+import com.beanspot.backend.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name="USER 관련 API", description = "마이페이지 관련 API입니다.")
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/me")
+    public ApiResponse<?> getProfile(@com.beanspot.backend.security.CurrentUserId Long userId) {
+         com.beanspot.backend.entity.User user = userService.getUserProfileById(userId);
+         return ApiResponse.ok(user);
+    }
+
+
+}

--- a/src/main/java/com/beanspot/backend/controller/UserController.java
+++ b/src/main/java/com/beanspot/backend/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.beanspot.backend.controller;
 
 import com.beanspot.backend.common.response.ApiResponse;
+import com.beanspot.backend.dto.user.UserProfileDTO;
+import com.beanspot.backend.entity.User;
 import com.beanspot.backend.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +21,7 @@ public class UserController {
 
     @GetMapping("/me")
     public ApiResponse<?> getProfile(@com.beanspot.backend.security.CurrentUserId Long userId) {
-         com.beanspot.backend.entity.User user = userService.getUserProfileById(userId);
+         UserProfileDTO user = userService.getUserProfileById(userId);
          return ApiResponse.ok(user);
     }
 

--- a/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
@@ -1,2 +1,43 @@
-package com.beanspot.backend.dto.admin;public class AnnouncementRequestDto {
+package com.beanspot.backend.dto.admin;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnnouncementRequestDto {
+
+    // 기본 사항 (피그마 1단계 & ERD 매칭)
+    private String title;              // 제목 (ERD: title)
+    private String organizer;          // 운영 주체 (ERD: organizer)
+    private String recruitmentCount;   // 모집 인원 (ERD: recruitment_count)
+    private String location;           // 활동 지역 (ERD: location)
+    private String recruitmentStart;   // 모집 시작일 (ERD: recruitment_start)
+    private String recruitmentEnd;     // 모집 종료일 (ERD: recruitment_end)
+    private String startDate;          // 활동 시작일 (ERD: start_date)
+    private String endDate;            // 활동 종료일 (ERD: end_date)
+    private String type;               // 공고 유형 (ERD: type - 예: 대외활동, 동아리)
+    private String imgUrl;             // 포스터 이미지 (ERD: img_url)
+    private String linkUrl;            // 신청 링크 (ERD: link_url)
+
+    // 상세 내용 및 마감 (피그마 2단계 & ERD 매칭)
+    private String content;            // 상세 내용 (ERD: content)
+    private String closingment;        // 마무리 멘트 (ERD: closingment)
+
+    // 세부 일정 (피그마 3단계: 리스트 형태)
+    private List<ScheduleDto> schedules;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ScheduleDto {
+        private String dateInfo;       // 날짜 (예: "01.11")
+        private String description;    // 일정 내용 (예: "대면 발대식 진행")
+    }
 }

--- a/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
@@ -1,43 +1,45 @@
-package com.beanspot.backend.dto.admin;
+package com.beanspot.backend.dto.admin; // 패키지 경로 확인
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+import lombok.*;
+import lombok.experimental.SuperBuilder; // 추가
 import java.util.List;
 
 @Getter
-@Builder
+@SuperBuilder // @Builder 대신 필수
 @NoArgsConstructor
 @AllArgsConstructor
 public class AnnouncementRequestDto {
+    private String title;
+    private String organizer;
+    private String recruitmentCount;
+    private String location;
+    private String recruitmentStart;
+    private String recruitmentEnd;
+    private String startDate;
+    private String endDate;
+    private String type;
+    private String imgUrl;
+    private String linkUrl;
+    private String content;
+    private String closingment;
 
-    // 기본 사항 (피그마 1단계 & ERD 매칭)
-    private String title;              // 제목 (ERD: title)
-    private String organizer;          // 운영 주체 (ERD: organizer)
-    private String recruitmentCount;   // 모집 인원 (ERD: recruitment_count)
-    private String location;           // 활동 지역 (ERD: location)
-    private String recruitmentStart;   // 모집 시작일 (ERD: recruitment_start)
-    private String recruitmentEnd;     // 모집 종료일 (ERD: recruitment_end)
-    private String startDate;          // 활동 시작일 (ERD: start_date)
-    private String endDate;            // 활동 종료일 (ERD: end_date)
-    private String type;               // 공고 유형 (ERD: type - 예: 대외활동, 동아리)
-    private String imgUrl;             // 포스터 이미지 (ERD: img_url)
-    private String linkUrl;            // 신청 링크 (ERD: link_url)
+    // 상세 필드들
+    private Boolean isServiceHoursVerified;
+    private Integer fee;
+    private String benefits;
+    private String selectionProcess;
+    private String prizeScale;
+    private String participantTarget;
+    private String teamSize;
+    private String curriculumUrl;
 
-    // 상세 내용 및 마감 (피그마 2단계 & ERD 매칭)
-    private String content;            // 상세 내용 (ERD: content)
-    private String closingment;        // 마무리 멘트 (ERD: closingment)
-
-    // 세부 일정 (피그마 3단계: 리스트 형태)
     private List<ScheduleDto> schedules;
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ScheduleDto {
-        private String dateInfo;       // 날짜 (예: "01.11")
-        private String description;    // 일정 내용 (예: "대면 발대식 진행")
+        private String dateInfo;
+        private String description;
     }
 }

--- a/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/admin/AnnouncementRequestDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.admin;public class AnnouncementRequestDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/admin/NoticeRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/admin/NoticeRequestDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.admin;public class NoticeRequestDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/auth/CheckNicknameResponseDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/CheckNicknameResponseDTO.java
@@ -1,0 +1,12 @@
+package com.beanspot.backend.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CheckNicknameResponseDTO {
+    private final boolean available; // 닉네임 사용 가능 여부
+    private final String nickname;   // 확인한 닉네임
+    private final String message;
+}

--- a/src/main/java/com/beanspot/backend/dto/auth/LoginUserDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/LoginUserDTO.java
@@ -12,7 +12,7 @@ public class LoginUserDTO {
     public static class Req {
         @NotBlank
         @Email
-        private String email;
+        private String userId;
         @NotBlank
         private String password;
     }
@@ -24,7 +24,7 @@ public class LoginUserDTO {
     public static class Res {
         private String accessToken;
         private String refreshToken;
-        private Long userId;
+        private Long id;
         private String nickname;
     }
 }

--- a/src/main/java/com/beanspot/backend/dto/auth/LoginUserDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/LoginUserDTO.java
@@ -1,0 +1,30 @@
+package com.beanspot.backend.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class LoginUserDTO {
+    @Getter
+    public static class Req {
+        @NotBlank
+        @Email
+        private String email;
+        @NotBlank
+        private String password;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Res {
+        private String accessToken;
+        private String refreshToken;
+        private Long userId;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/beanspot/backend/dto/auth/SignUpSocialUserDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/SignUpSocialUserDTO.java
@@ -1,20 +1,19 @@
 package com.beanspot.backend.dto.auth;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-public class LoginUserDTO {
+public class SignUpSocialUserDTO {
+
     @Getter
     public static class Req {
-        @NotBlank
-        @Email
-        private String userId;
-        @NotBlank
-        private String password;
+        @NotBlank(message = "닉네임 작성은 필수입니다.")
+        private String nickname;
+        private String userName;
+        private String phone;
     }
 
     @Builder
@@ -22,10 +21,7 @@ public class LoginUserDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Res {
-        private String accessToken;
-        private String refreshToken;
-        private Long id;
+        private String socialId;
         private String nickname;
-        private Boolean isProfileComplete;
     }
 }

--- a/src/main/java/com/beanspot/backend/dto/auth/SignUpUserDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/SignUpUserDTO.java
@@ -1,0 +1,41 @@
+package com.beanspot.backend.dto.auth;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class SignUpUserDTO {
+
+    @Getter
+    public static class Req {
+        @Email
+        @NotBlank(message = "이메일 입력은 필수입니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호 입력은 필수입니다.")
+        private String password;
+
+        @NotBlank(message = "닉네임 작성은 필수입니다.")
+        private String nickname;
+
+        @NotBlank(message = "사용자 이름 작성은 필수입니다.")
+        private String name;
+
+        private String phone;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Res {
+        private String email;
+        private String nickname;
+        private boolean emailVerified;
+    }
+}

--- a/src/main/java/com/beanspot/backend/dto/auth/SignUpUserDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/auth/SignUpUserDTO.java
@@ -13,9 +13,8 @@ public class SignUpUserDTO {
 
     @Getter
     public static class Req {
-        @Email
-        @NotBlank(message = "이메일 입력은 필수입니다.")
-        private String email;
+        @NotBlank(message = "아이디 입력은 필수입니다.")
+        private String userId;
 
         @NotBlank(message = "비밀번호 입력은 필수입니다.")
         private String password;
@@ -34,7 +33,7 @@ public class SignUpUserDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Res {
-        private String email;
+        private String userId;
         private String nickname;
         private boolean emailVerified;
     }

--- a/src/main/java/com/beanspot/backend/dto/user/CalendarDailyResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/CalendarDailyResponseDto.java
@@ -1,0 +1,25 @@
+package com.beanspot.backend.dto.user;
+
+import lombok.*;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Builder @NoArgsConstructor @AllArgsConstructor
+public class CalendarDailyResponseDto {
+    private LocalDate date;
+    private List<TodoDetail> todos;
+    private DiaryDetail diary; // 일기는 없을 수도 있으니 단건
+
+    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    public static class TodoDetail {
+        private Long id;
+        private String content;
+        private boolean isCompleted;
+    }
+
+    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    public static class DiaryDetail {
+        private String content;
+        private String emotionType;
+    }
+}

--- a/src/main/java/com/beanspot/backend/dto/user/CalendarResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/CalendarResponseDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.user;public class CalendarResponseDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.user;public class DiaryRequestDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
@@ -1,2 +1,28 @@
-package com.beanspot.backend.dto.user;public class DiaryRequestDto {
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.entity.CharacterType;
+import com.beanspot.backend.entity.EmotionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryRequestDto {
+
+    @Schema(description = "일기 작성 날짜", example = "2026-01-30")
+    private LocalDate date;
+
+    @Schema(description = "캐릭터 타입 (GREEN: 푸웅, BROWN: 꾸웅)", example = "GREEN")
+    private CharacterType characterType;
+
+    @Schema(description = "감정 타입 (HAPPY, SAD, ANGRY 등)", example = "HAPPY")
+    private EmotionType emotionType;
+
+    @Schema(description = "일기 내용 (최대 200자)", example = "오늘은 스프링 부트 설정을 마쳤다. 뿌듯하다!")
+    private String content;
 }

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
@@ -1,2 +1,48 @@
-package com.beanspot.backend.dto.user;public class DiaryResponseDto {
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.entity.CharacterType;
+import com.beanspot.backend.entity.Diary;
+import com.beanspot.backend.entity.EmotionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryResponseDto {
+
+    @Schema(description = "일기 ID (고유 번호)", example = "1")
+    private Long id;
+
+    @Schema(description = "일기 작성 날짜", example = "2026-01-30")
+    private LocalDate date;
+
+    @Schema(description = "캐릭터 타입", example = "GREEN")
+    private CharacterType characterType;
+
+    @Schema(description = "감정 타입", example = "HAPPY")
+    private EmotionType emotionType;
+
+    @Schema(description = "일기 내용", example = "오늘은 스프링 부트 기능을 완성했다!")
+    private String content;
+
+    /**
+     * Entity -> DTO 변환 메서드
+     * 서비스 계층에서 DB 데이터를 DTO로 편하게 바꾸기 위해 사용합니다.
+     */
+    public static DiaryResponseDto from(Diary diary) {
+        return DiaryResponseDto.builder()
+                .id(diary.getId())
+                .date(diary.getDate())
+                .characterType(diary.getCharacterType())
+                .emotionType(diary.getEmotionType())
+                .content(diary.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.user;public class DiaryResponseDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/user/FeedbackRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/FeedbackRequestDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.user;public class FeedbackRequestDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/user/TodoRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/TodoRequestDto.java
@@ -1,0 +1,12 @@
+package com.beanspot.backend.dto.user;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TodoRequestDto {
+    private String content; // 할 일 내용
+    private LocalDate date; // 해당 날짜
+}

--- a/src/main/java/com/beanspot/backend/dto/user/TodoResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/TodoResponseDto.java
@@ -1,0 +1,29 @@
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.entity.Todo; // 💡 Todo 엔티티를 불러옵니다.
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate; // 💡 LocalDate 도구를 불러옵니다.
+
+@Getter
+@Builder
+@NoArgsConstructor // 💡 기본 생성자도 추가하는 것이 안전합니다.
+@AllArgsConstructor
+public class TodoResponseDto {
+    private Long id;
+    private String content;
+    private boolean isCompleted;
+    private LocalDate date;
+
+    public static TodoResponseDto from(Todo todo) {
+        return TodoResponseDto.builder()
+                .id(todo.getId())
+                .content(todo.getContent())
+                .isCompleted(todo.isCompleted())
+                .date(todo.getDate())
+                .build();
+    }
+}

--- a/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
@@ -1,0 +1,18 @@
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.domain.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserProfileDTO {
+    private Long userId;
+    private String nickname;
+    private String name;
+    private String email;
+    private String phone;
+    private String profileUrl;
+    private String address;
+    private SocialType socialType;
+}

--- a/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
@@ -8,12 +8,13 @@ import lombok.Getter;
 @Builder
 @Getter
 public class UserProfileDTO {
-    private Long userId;
+    private Long id;
+    private String userId;
     private String nickname;
     private String name;
-    private String email;
     private String phone;
     private String profileUrl;
     private String address;
+    private String socialId;
     private SocialType socialType;
 }

--- a/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/user/UserProfileDTO.java
@@ -1,6 +1,7 @@
 package com.beanspot.backend.dto.user;
 
-import com.beanspot.backend.domain.SocialType;
+
+import com.beanspot.backend.entity.SocialType;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/beanspot/backend/dto/user/UserProfileUpdateDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/UserProfileUpdateDto.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.dto.user;public class UserProfileUpdateDto {
+}

--- a/src/main/java/com/beanspot/backend/dto/user/UserSummaryDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/user/UserSummaryDTO.java
@@ -1,0 +1,11 @@
+package com.beanspot.backend.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserSummaryDTO {
+    private Long userId;
+    private String nickname;
+}

--- a/src/main/java/com/beanspot/backend/entity/Announcement.java
+++ b/src/main/java/com/beanspot/backend/entity/Announcement.java
@@ -1,2 +1,60 @@
-package com.beanspot.backend.entity;public class Announcement {
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "announcement_common") // ERD 명칭 반영
+public class Announcement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "announcement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private User admin; // 등록한 관리자
+
+    private String title;          // 공고 제목
+
+    @Column(columnDefinition = "TEXT")
+    private String content;        // 상세 내용 (피그마 2단계)
+
+    private String organizer;      // 운영 주체 (기존 host 대신 피그마 명칭 반영)
+    private String recruitmentCount; // 모집 인원
+    private String location;       // 활동 지역
+
+    private LocalDateTime recruitmentStart; // 모집 시작일
+    private LocalDateTime recruitmentEnd;   // 모집 종료일
+
+    private LocalDateTime startDate; // 활동 시작일
+    private LocalDateTime endDate;   // 활동 종료일
+
+    private String type;           // 공고 유형 (대외활동, 동아리 등)
+    private String imgUrl;         // 포스터 이미지 URL
+    private String linkUrl;         // 신청 링크 URL
+
+    private String closingment;    // 마무리 멘트 (피그마 2단계 하단)
+
+    @Builder.Default
+    private Integer viewCount = 0; // 조회수 (초기값 0)
+
+    // ⭐ 세부 일정과의 1:N 관계 설정 (피그마 3단계)
+    @Builder.Default
+    @OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AnnouncementSchedule> schedules = new ArrayList<>();
+
+    // == 연관관계 편의 메서드 == //
+    public void addSchedule(AnnouncementSchedule schedule) {
+        this.schedules.add(schedule);
+        schedule.setAnnouncement(this);
+    }
 }

--- a/src/main/java/com/beanspot/backend/entity/Announcement.java
+++ b/src/main/java/com/beanspot/backend/entity/Announcement.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Announcement {
+}

--- a/src/main/java/com/beanspot/backend/entity/Announcement.java
+++ b/src/main/java/com/beanspot/backend/entity/Announcement.java
@@ -2,17 +2,21 @@ package com.beanspot.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@Setter // 값 변경이 잦을 경우 대비
+@SuperBuilder // 상속 관계에서 Builder를 사용하기 위해 필요
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "announcement_common") // ERD 명칭 반영
-public class Announcement extends BaseEntity {
+@Inheritance(strategy = InheritanceType.JOINED) // 조인 전략 선택
+@DiscriminatorColumn(name = "type") // 부모 테이블에 자동 생성될 구분 컬럼명
+@Table(name = "announcement")
+public abstract class Announcement extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,14 +25,14 @@ public class Announcement extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "admin_id")
-    private User admin; // 등록한 관리자
+    private User admin;
 
     private String title;          // 공고 제목
 
     @Column(columnDefinition = "TEXT")
-    private String content;        // 상세 내용 (피그마 2단계)
+    private String content;        // 상세 내용
 
-    private String organizer;      // 운영 주체 (기존 host 대신 피그마 명칭 반영)
+    private String organizer;      // 운영 주체
     private String recruitmentCount; // 모집 인원
     private String location;       // 활동 지역
 
@@ -38,16 +42,13 @@ public class Announcement extends BaseEntity {
     private LocalDateTime startDate; // 활동 시작일
     private LocalDateTime endDate;   // 활동 종료일
 
-    private String type;           // 공고 유형 (대외활동, 동아리 등)
     private String imgUrl;         // 포스터 이미지 URL
-    private String linkUrl;         // 신청 링크 URL
-
-    private String closingment;    // 마무리 멘트 (피그마 2단계 하단)
+    private String linkUrl;        // 신청 링크 URL
+    private String closingment;    // 마무리 멘트
 
     @Builder.Default
-    private Integer viewCount = 0; // 조회수 (초기값 0)
+    private Integer viewCount = 0; // 조회수
 
-    // ⭐ 세부 일정과의 1:N 관계 설정 (피그마 3단계)
     @Builder.Default
     @OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AnnouncementSchedule> schedules = new ArrayList<>();

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementChallenge.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementChallenge.java
@@ -1,0 +1,28 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("CHALLENGE")
+@Table(name = "announcement_challenge")
+public class AnnouncementChallenge extends Announcement {
+
+    @Column(name = "prize_scale")
+    private String prizeScale; // 시상 규모 (Comment: 시상 규모)
+
+    @Column(name = "participant_target")
+    private String participantTarget; // 모집 대상 (Comment: 모집 대상)
+
+    @Column(name = "team_size")
+    private String teamSize; // 팀원 규모 (Comment: 팀원 규모)
+}

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementEducation.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementEducation.java
@@ -1,0 +1,25 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("EDUCATION")
+@Table(name = "announcement_education")
+public class AnnouncementEducation extends Announcement {
+
+    @Column(name = "fee")
+    private Integer fee; // 참가비/비용 (Comment: 참가비/비용)
+
+    @Column(name = "curriculum_url")
+    private String curriculumUrl; // 세부 커리큘럼 (Comment: 세부 커리큘럼)
+}

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementSchedule.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementSchedule.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class AnnouncementSchedule {
+}

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementSchedule.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementSchedule.java
@@ -1,2 +1,24 @@
-package com.beanspot.backend.entity;public class AnnouncementSchedule {
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter // 연관관계 편의 메서드에서 사용
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnnouncementSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announcement_id")
+    private Announcement announcement; // 어떤 공고의 일정인지
+
+    private String dateInfo;    // 날짜 (예: "01.11")
+    private String description; // 내용 (예: "대면 발대식 진행")
 }

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementSupporter.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementSupporter.java
@@ -1,0 +1,25 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("SUPPORTER")
+@Table(name = "announcement_supporter")
+public class AnnouncementSupporter extends Announcement {
+
+    @Column(name = "benefits")
+    private String benefits; // 활동 혜택 (Comment: 활동 혜택)
+
+    @Column(name = "selection_process")
+    private String selectionProcess; // 심사 방식 (Comment: 심사 방식)
+}

--- a/src/main/java/com/beanspot/backend/entity/AnnouncementVolunteer.java
+++ b/src/main/java/com/beanspot/backend/entity/AnnouncementVolunteer.java
@@ -1,0 +1,25 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("VOLUNTEER") // 부모 테이블(announcement)의 type 컬럼에 저장될 값
+@Table(name = "announcement_volunteer") // ERD에 정의된 테이블명
+public class AnnouncementVolunteer extends Announcement {
+
+    @Column(name = "is_service_hours_verified")
+    private Boolean isServiceHoursVerified; // 봉사시간 인정 여부 (Comment: 봉사시간 인정 여부)
+
+    @Column(name = "fee")
+    private Integer fee; // 참가비 (Comment: 참가비)
+}

--- a/src/main/java/com/beanspot/backend/entity/BaseEntity.java
+++ b/src/main/java/com/beanspot/backend/entity/BaseEntity.java
@@ -2,7 +2,11 @@ package com.beanspot.backend.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +16,9 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@SuperBuilder // 1. 상속 관계 빌더를 위해 반드시 추가
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 2. JPA 엔티티를 위한 기본 생성자
+@AllArgsConstructor // 3. SuperBuilder 사용을 위한 전체 생성자
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/com/beanspot/backend/entity/BaseEntity.java
+++ b/src/main/java/com/beanspot/backend/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/beanspot/backend/entity/CharacterType.java
+++ b/src/main/java/com/beanspot/backend/entity/CharacterType.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class CharacterType {
+}

--- a/src/main/java/com/beanspot/backend/entity/CharacterType.java
+++ b/src/main/java/com/beanspot/backend/entity/CharacterType.java
@@ -1,2 +1,3 @@
-package com.beanspot.backend.entity;public class CharacterType {
-}
+package com.beanspot.backend.entity;
+
+public enum CharacterType { GREEN, BROWN }

--- a/src/main/java/com/beanspot/backend/entity/Diary.java
+++ b/src/main/java/com/beanspot/backend/entity/Diary.java
@@ -1,2 +1,47 @@
-package com.beanspot.backend.entity;public class Diary {
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate date;
+
+    @Enumerated(EnumType.STRING)
+    private CharacterType characterType; // GREEN(푸웅), BROWN(꾸웅)
+
+    @Enumerated(EnumType.STRING)
+    private EmotionType emotionType;     // HAPPY, SAD, ANGRY 등 6종
+
+    @Column(length = 200)
+    private String content; // 최대 200자
+
+    @Builder
+    public Diary(User user, LocalDate date, CharacterType characterType, EmotionType emotionType, String content) {
+        this.user = user;
+        this.date = date;
+        this.characterType = characterType;
+        this.emotionType = emotionType;
+        this.content = content;
+    }
+
+    // Diary.java 엔터티 내부에 추가
+    public void update(LocalDate date, CharacterType characterType, EmotionType emotionType, String content) {
+        this.date = date;
+        this.characterType = characterType;
+        this.emotionType = emotionType;
+        this.content = content;
+    }
 }
+

--- a/src/main/java/com/beanspot/backend/entity/Diary.java
+++ b/src/main/java/com/beanspot/backend/entity/Diary.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Diary {
+}

--- a/src/main/java/com/beanspot/backend/entity/EmotionType.java
+++ b/src/main/java/com/beanspot/backend/entity/EmotionType.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class EmotionType {
+}

--- a/src/main/java/com/beanspot/backend/entity/EmotionType.java
+++ b/src/main/java/com/beanspot/backend/entity/EmotionType.java
@@ -1,2 +1,4 @@
-package com.beanspot.backend.entity;public class EmotionType {
-}
+package com.beanspot.backend.entity;
+
+public enum EmotionType { HAPPY, ANGRY, SAD, SURPRISED, CALM, TIRED }
+

--- a/src/main/java/com/beanspot/backend/entity/Feedback.java
+++ b/src/main/java/com/beanspot/backend/entity/Feedback.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Feedback {
+}

--- a/src/main/java/com/beanspot/backend/entity/Notice.java
+++ b/src/main/java/com/beanspot/backend/entity/Notice.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Notice {
+}

--- a/src/main/java/com/beanspot/backend/entity/Report.java
+++ b/src/main/java/com/beanspot/backend/entity/Report.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Report {
+}

--- a/src/main/java/com/beanspot/backend/entity/Role.java
+++ b/src/main/java/com/beanspot/backend/entity/Role.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Role {
+}

--- a/src/main/java/com/beanspot/backend/entity/Role.java
+++ b/src/main/java/com/beanspot/backend/entity/Role.java
@@ -1,2 +1,13 @@
-package com.beanspot.backend.entity;public class Role {
+package com.beanspot.backend.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    ROLE_USER("일반 사용자"),
+    ROLE_ADMIN("관리자");
+
+    private final String description;
 }

--- a/src/main/java/com/beanspot/backend/entity/SocialType.java
+++ b/src/main/java/com/beanspot/backend/entity/SocialType.java
@@ -1,0 +1,16 @@
+package com.beanspot.backend.entity;
+
+public enum SocialType {
+    KAKAO,
+    NAVER,
+    GOOGLE,
+    NONE;
+
+    public static SocialType from(String input){
+        try{
+            return SocialType.valueOf(input.toUpperCase());
+        }catch (IllegalArgumentException e){
+            throw new IllegalArgumentException("Invalid social type: " + input);
+        }
+    }
+}

--- a/src/main/java/com/beanspot/backend/entity/Todo.java
+++ b/src/main/java/com/beanspot/backend/entity/Todo.java
@@ -1,0 +1,43 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder // 클래스 레벨로 이동하여 더 유연하게 사용합니다.
+public class Todo extends BaseEntity { // 💡 BaseEntity 상속 추가
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate date;    // 어느 날짜의 할 일인지
+
+    private String content;    // 할 일 내용
+
+    private boolean isCompleted; // 완료 여부
+
+    /**
+     * 💡 투두 상태 변경 (완료/미완료 토글)
+     * 서비스 계층에서 호출하여 DB 데이터를 변경합니다.
+     */
+    public void toggle() {
+        this.isCompleted = !this.isCompleted;
+    }
+
+    /**
+     * 💡 투두 내용 수정
+     * 나중에 할 일 내용을 고치고 싶을 때 사용합니다.
+     */
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/beanspot/backend/entity/User.java
+++ b/src/main/java/com/beanspot/backend/entity/User.java
@@ -47,4 +47,20 @@ public class User extends BaseEntity{
 
     private boolean emailVerified;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role; // ROLE_USER, ROLE_ADMIN
+
+
+    public void updateProfile(String nickname, String profileUrl) {
+        // 닉네임이 비어있지 않은 경우에만 업데이트 (피그마 3-2 반영)
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname;
+        }
+        // 새로운 이미지 경로가 들어온 경우에만 업데이트 (피그마 2 반영)
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+    }
+
 }

--- a/src/main/java/com/beanspot/backend/entity/User.java
+++ b/src/main/java/com/beanspot/backend/entity/User.java
@@ -14,7 +14,8 @@ public class User extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String email; // 사용자 이메일
+    @Column(name = "user_id")
+    private String userId; // 사용자 아이디
 
     @Column(name = "password", length = 100)
     private String password; // 비밀번호
@@ -28,6 +29,10 @@ public class User extends BaseEntity{
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type")
     private SocialType socialType; // 카카오, 네이버 등
+
+    @Column(name = "social_id", unique = true)
+    private String socialId;
+
 
     @Column(name = "profile_url")
     private String profileUrl; // 프로필 이미지 경로

--- a/src/main/java/com/beanspot/backend/entity/User.java
+++ b/src/main/java/com/beanspot/backend/entity/User.java
@@ -1,0 +1,45 @@
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = "nickname")})
+public class User extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email; // 사용자 이메일
+
+    @Column(name = "password", length = 100)
+    private String password; // 비밀번호
+
+    private String name; // 본명
+
+    @Column(unique = true, nullable = false, length = 15)
+    private String nickname; // 닉네임
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type")
+    private SocialType socialType; // 카카오, 네이버 등
+
+    @Column(name = "profile_url")
+    private String profileUrl; // 프로필 이미지 경로
+
+    @Column(length = 20, unique = true)
+    private String phone; // 휴대번호
+
+    private String address; // 주소
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    private boolean emailVerified;
+
+}

--- a/src/main/java/com/beanspot/backend/entity/User.java
+++ b/src/main/java/com/beanspot/backend/entity/User.java
@@ -8,59 +8,69 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = "nickname")})
-public class User extends BaseEntity{
+@Table(name = "user", uniqueConstraints = {@UniqueConstraint(columnNames = "nickname")})
+public class User extends BaseEntity { // BaseEntity 상속으로 생성/수정 시간 관리
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "user_id")
-    private String userId; // 사용자 아이디
+    private String userId; // 사용자 로그인 아이디
 
     @Column(name = "password", length = 100)
-    private String password; // 비밀번호
+    private String password; // 암호화된 비밀번호
 
-    private String name; // 본명
+    private String name; // 사용자 실명
 
     @Column(unique = true, nullable = false, length = 15)
-    private String nickname; // 닉네임
-
+    private String nickname; // 서비스 활동 닉네임
 
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type")
-    private SocialType socialType; // 카카오, 네이버 등
+    private SocialType socialType; // KAKAO, NAVER 등
 
     @Column(name = "social_id", unique = true)
-    private String socialId;
-
+    private String socialId; // 소셜 서비스 고유 식별값
 
     @Column(name = "profile_url")
     private String profileUrl; // 프로필 이미지 경로
 
     @Column(length = 20, unique = true)
-    private String phone; // 휴대번호
+    private String phone; // 연락처
 
-    private String address; // 주소
+    private String address; // 주소 정보
 
     @Column(name = "refresh_token")
-    private String refreshToken;
+    private String refreshToken; // JWT 갱신용 토큰
 
-    private boolean emailVerified;
+    private boolean emailVerified; // 이메일 인증 여부
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role; // ROLE_USER, ROLE_ADMIN
 
+    /**
+     * 💡 핵심 수정 사항: 데이터 저장 전 기본값 할당
+     * @Builder 사용 시 필드 초기값이 null이 되는 문제를 방지합니다.
+     */
 
+    @PrePersist
+    public void prePersist() {
+        if (this.role == null) {
+            this.role = Role.ROLE_USER; // 타입을 Role로 통일!
+        }
+    }
+
+    /**
+     * 프로필 정보 업데이트 (닉네임 및 이미지)
+     */
     public void updateProfile(String nickname, String profileUrl) {
-        // 닉네임이 비어있지 않은 경우에만 업데이트 (피그마 3-2 반영)
         if (nickname != null && !nickname.isBlank()) {
             this.nickname = nickname;
         }
-        // 새로운 이미지 경로가 들어온 경우에만 업데이트 (피그마 2 반영)
         if (profileUrl != null) {
             this.profileUrl = profileUrl;
         }
     }
-
 }

--- a/src/main/java/com/beanspot/backend/entity/Volunteer.java
+++ b/src/main/java/com/beanspot/backend/entity/Volunteer.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.entity;public class Volunteer {
+}

--- a/src/main/java/com/beanspot/backend/oauth/KakaoInfo.java
+++ b/src/main/java/com/beanspot/backend/oauth/KakaoInfo.java
@@ -1,0 +1,38 @@
+package com.beanspot.backend.oauth;
+
+import java.util.Map;
+
+public class KakaoInfo extends OauthUserInfo{
+    public KakaoInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> temp = (Map)attributes.get("properties");
+        return (String)temp.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> temp = (Map)attributes.get("kakao_account");
+        return (String)temp.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> temp = (Map)attributes.get("properties");
+
+        return (String)temp.get("profile_image");
+    }
+
+    @Override
+    public String getUsername() {
+        return "Kakao_"+attributes.get("id").toString();
+    }
+}

--- a/src/main/java/com/beanspot/backend/oauth/OauthUserInfo.java
+++ b/src/main/java/com/beanspot/backend/oauth/OauthUserInfo.java
@@ -1,0 +1,20 @@
+package com.beanspot.backend.oauth;
+
+import java.util.Map;
+
+public abstract class OauthUserInfo {
+    protected Map<String, Object> attributes;
+
+    public OauthUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+    public abstract String getUsername();
+    public abstract String getId();
+    public abstract String getName();
+    public abstract String getEmail();
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
@@ -4,6 +4,10 @@ import com.beanspot.backend.entity.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+    // 모든 유형의 공고를 최신순으로 조회하는 예시
+    List<Announcement> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
@@ -1,2 +1,9 @@
-package com.beanspot.backend.repository;public interface AnnouncementRepository {
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
 }

--- a/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/AnnouncementRepository.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.repository;public interface AnnouncementRepository {
+}

--- a/src/main/java/com/beanspot/backend/repository/ChallengeRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/ChallengeRepository.java
@@ -1,0 +1,13 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.AnnouncementChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChallengeRepository extends JpaRepository<AnnouncementChallenge, Long> {
+    // 특정 모집 대상을 기준으로 조회하는 예시
+    List<AnnouncementChallenge> findByParticipantTargetContaining(String target);
+}

--- a/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.repository;public class DiaryRepository {
+}

--- a/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
@@ -1,2 +1,25 @@
-package com.beanspot.backend.repository;public class DiaryRepository {
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional; // Optional을 사용해야 orElse(null)을 쓸 수 있습니다.
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    /**
+     * 특정 사용자의 특정 기간(한 달) 동안의 일기 목록을 조회합니다.
+     * 캘린더에 일기 아이콘을 표시할 때 사용합니다.
+     */
+    List<Diary> findAllByUserIdAndDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+
+    // [일별 상세 조회] 이번에 추가해야 할 메서드
+    Optional<Diary> findByUserIdAndDate(Long memberId, LocalDate date);
+
+
+
+
 }

--- a/src/main/java/com/beanspot/backend/repository/EducationRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/EducationRepository.java
@@ -1,0 +1,13 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.AnnouncementEducation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EducationRepository extends JpaRepository<AnnouncementEducation, Long> {
+    // 참가비가 0원(무료)인 교육 공고만 조회하는 예시
+    List<AnnouncementEducation> findByFee(Integer fee);
+}

--- a/src/main/java/com/beanspot/backend/repository/FeedbackRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/FeedbackRepository.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.repository;public interface FeedbackRepository {
+}

--- a/src/main/java/com/beanspot/backend/repository/NoticeRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/NoticeRepository.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.repository;public interface NoticeRepository {
+}

--- a/src/main/java/com/beanspot/backend/repository/ReportRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/ReportRepository.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.repository;public interface ReportRepository {
+}

--- a/src/main/java/com/beanspot/backend/repository/SupporterRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/SupporterRepository.java
@@ -1,0 +1,9 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.AnnouncementSupporter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SupporterRepository extends JpaRepository<AnnouncementSupporter, Long> {
+}

--- a/src/main/java/com/beanspot/backend/repository/TodoRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/TodoRepository.java
@@ -1,0 +1,11 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+    // 특정 회원의 특정 날짜 투두 리스트 조회
+    List<Todo> findAllByUserIdAndDate(Long memberId, LocalDate date);
+}

--- a/src/main/java/com/beanspot/backend/repository/UserRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Optional;
+
+@RequestMapping
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Boolean existsByNickname(String nickname);
+    Boolean existsByEmail(String email);
+    User findByEmailAndPassword(String email, String password);
+}

--- a/src/main/java/com/beanspot/backend/repository/UserRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByNickname(String nickname);
     Boolean existsByUserId(String userId);
     User findByUserIdAndPassword(String userId, String password);
+
+    Optional<User> findBySocialId(String socialId);
+    Boolean existsBySocialId(String socialId);
 }

--- a/src/main/java/com/beanspot/backend/repository/UserRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/UserRepository.java
@@ -8,8 +8,8 @@ import java.util.Optional;
 
 @RequestMapping
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUserId(String userId);
     Boolean existsByNickname(String nickname);
-    Boolean existsByEmail(String email);
-    User findByEmailAndPassword(String email, String password);
+    Boolean existsByUserId(String userId);
+    User findByUserIdAndPassword(String userId, String password);
 }

--- a/src/main/java/com/beanspot/backend/repository/VolunteerRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/VolunteerRepository.java
@@ -1,0 +1,13 @@
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.AnnouncementVolunteer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface VolunteerRepository extends JpaRepository<AnnouncementVolunteer, Long> {
+    // 봉사시간 인증이 가능한 공고만 조회하는 예시 쿼리 메서드
+    List<AnnouncementVolunteer> findByIsServiceHoursVerifiedTrue();
+}

--- a/src/main/java/com/beanspot/backend/security/CurrentUser.java
+++ b/src/main/java/com/beanspot/backend/security/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.beanspot.backend.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+
+}
+

--- a/src/main/java/com/beanspot/backend/security/CurrentUserId.java
+++ b/src/main/java/com/beanspot/backend/security/CurrentUserId.java
@@ -1,6 +1,8 @@
 package com.beanspot.backend.security;
 
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import java.lang.annotation.*;
 
 @Target({ElementType.PARAMETER, ElementType.TYPE})

--- a/src/main/java/com/beanspot/backend/security/CurrentUserId.java
+++ b/src/main/java/com/beanspot/backend/security/CurrentUserId.java
@@ -1,0 +1,11 @@
+package com.beanspot.backend.security;
+
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal(expression = "id")
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/beanspot/backend/security/CurrentUserSocialId.java
+++ b/src/main/java/com/beanspot/backend/security/CurrentUserSocialId.java
@@ -1,0 +1,12 @@
+package com.beanspot.backend.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal(expression = "socialId")
+public @interface CurrentUserSocialId {
+}

--- a/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
+++ b/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
@@ -2,7 +2,7 @@ package com.beanspot.backend.security;
 
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
-import com.beanspot.backend.domain.User;
+import com.beanspot.backend.entity.User;
 import com.beanspot.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
+++ b/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
@@ -31,5 +31,9 @@ public class CustomUserDetailService implements UserDetailsService {
                 .orElseThrow(()-> new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS));
         return UserPrincipal.from(user);
     }
+    public UserDetails loadUserBySocicalId(String socicalId) {
+        User user = User.builder().socialId(socicalId).build();
 
+        return UserPrincipal.from(user);
+    }
 }

--- a/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
+++ b/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
@@ -20,8 +20,8 @@ public class CustomUserDetailService implements UserDetailsService {
 
     // username => email 로그인
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_EMAIL_NOT_FOUND));
         return UserPrincipal.from(user);
     }

--- a/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
+++ b/src/main/java/com/beanspot/backend/security/CustomUserDetailService.java
@@ -1,0 +1,35 @@
+package com.beanspot.backend.security;
+
+import com.beanspot.backend.common.exception.CustomException;
+import com.beanspot.backend.common.exception.ErrorCode;
+import com.beanspot.backend.domain.User;
+import com.beanspot.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    @Autowired
+    private final UserRepository userRepository;
+
+    // username => email 로그인
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_EMAIL_NOT_FOUND));
+        return UserPrincipal.from(user);
+    }
+
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(()-> new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+        return UserPrincipal.from(user);
+    }
+
+}

--- a/src/main/java/com/beanspot/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/beanspot/backend/security/JwtAuthenticationFilter.java
@@ -32,29 +32,76 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try{
+            //요청 경로 추출
+            String requestUri = request.getRequestURI();
+            //토큰 추출
             String token = parseBearerToken(request);
+
             if(StringUtils.hasText(token) && !token.equalsIgnoreCase("null")){
-                if(tokenProvider.validateToken(token)) {
-                    Long userId = tokenProvider.getUserIdFromToken(token);
-                    log.info("User id is {}", userId);
+                if(requestUri.startsWith("/api/auth/oauth/kakao/signup")){
+                    if(!validateTemporaryToken(token, request, response)) return; //임시 토큰이 유효하지 않으면 필터 체인을 진행하지 않음.
+                }else{
+                    if(tokenProvider.validateToken(token)) {
+                        String tokenType = tokenProvider.getTokenType(token);
+                        //일반 토큰과 임시 토큰을 분리해서 처리해야 함.
+                        if("access".equals(tokenType)){
+                            Long userId = tokenProvider.getUserIdFromToken(token);
+                            log.info("User id is {}", userId);
 
-                    UserDetails userDetails = customUserDetailService.loadUserById(userId);
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                            UserDetails userDetails = customUserDetailService.loadUserById(userId);
+                            UsernamePasswordAuthenticationToken authentication =
+                                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
-//                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userId, null,
-//                            AuthorityUtils.NO_AUTHORITIES);
-
-                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-                    securityContext.setAuthentication(authentication);
-                    SecurityContextHolder.setContext(securityContext);
+                            //                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userId, null,
+                            //                            AuthorityUtils.NO_AUTHORITIES);
+                            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                            log.info("Authenticated user {}", authentication);
+                            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                            securityContext.setAuthentication(authentication);
+                            SecurityContextHolder.setContext(securityContext);
+                        }
+                    }
                 }
+
             }
         }catch (Exception ex) {
             logger.error("could not set user authentication in security context", ex);
         }
         filterChain.doFilter(request, response);
+    }
+
+    private boolean validateTemporaryToken(String token, HttpServletRequest request, HttpServletResponse response) {
+        if(tokenProvider.validateToken(token)) {
+            String tokenType = tokenProvider.getTokenType(token);
+            if ("temporary".equals(tokenType)) {
+                String socialId = tokenProvider.getSocialIdFromToken(token);
+                String socialType = tokenProvider.getSocialTypeFromToken(token);
+
+                log.info("Temporary token detected. Social ID: {} and Social Type: {}", socialId, socialType);
+
+                //소셜 아이디를 SecurityContext에 저장
+                UserDetails userDetails = customUserDetailService.loadUserBySocicalId(socialId);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                log.info("Authenticated user {}", authentication);
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                securityContext.setAuthentication(authentication);
+                SecurityContextHolder.setContext(securityContext);
+
+                response.setStatus(HttpServletResponse.SC_OK);
+                return true;
+            }else{
+                // 'temporary' 토큰이 아니면, 허용되지 않는 토큰 타입
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return false; // 인증 실패
+            }
+        }else{
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            log.error("it is not a temporary token");
+            return false;
+        }
     }
 
     private String parseBearerToken(HttpServletRequest request) {

--- a/src/main/java/com/beanspot/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/beanspot/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.beanspot.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private final TokenProvider tokenProvider;
+    @Autowired
+    private final CustomUserDetailService customUserDetailService;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            String token = parseBearerToken(request);
+            if(StringUtils.hasText(token) && !token.equalsIgnoreCase("null")){
+                if(tokenProvider.validateToken(token)) {
+                    Long userId = tokenProvider.getUserIdFromToken(token);
+                    log.info("User id is {}", userId);
+
+                    UserDetails userDetails = customUserDetailService.loadUserById(userId);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+//                    AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userId, null,
+//                            AuthorityUtils.NO_AUTHORITIES);
+
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                    securityContext.setAuthentication(authentication);
+                    SecurityContextHolder.setContext(securityContext);
+                }
+            }
+        }catch (Exception ex) {
+            logger.error("could not set user authentication in security context", ex);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseBearerToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/beanspot/backend/security/TokenProvider.java
+++ b/src/main/java/com/beanspot/backend/security/TokenProvider.java
@@ -26,7 +26,7 @@ public class TokenProvider {
     @Value("${jwt.refresh-token-validity-in-seconds}")
     private long refreshTokenValidityInSeconds;
 
-    @Value("${jwt.allowed-clock-skew-seconds:60}")
+    @Value("${jwt.allowed-clock-skew-seconds}")
     private long allowedClockSkewSeconds;
 
     private JwtParser parser;

--- a/src/main/java/com/beanspot/backend/security/TokenProvider.java
+++ b/src/main/java/com/beanspot/backend/security/TokenProvider.java
@@ -48,7 +48,7 @@ public class TokenProvider {
                 .setIssuedAt(new Date())
                 .setExpiration(expiryDate) // exp
                 .setSubject(user.getId().toString())
-                .claim("email", user.getEmail())
+                .claim("userId", user.getUserId())
                 .claim("name", user.getNickname())
                 .claim("type", "access")
                 .compact();

--- a/src/main/java/com/beanspot/backend/security/TokenProvider.java
+++ b/src/main/java/com/beanspot/backend/security/TokenProvider.java
@@ -1,6 +1,6 @@
 package com.beanspot.backend.security;
 
-import com.beanspot.backend.domain.User;
+import com.beanspot.backend.entity.User;
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/beanspot/backend/security/TokenProvider.java
+++ b/src/main/java/com/beanspot/backend/security/TokenProvider.java
@@ -1,0 +1,107 @@
+package com.beanspot.backend.security;
+
+import com.beanspot.backend.domain.User;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.token-validity-in-seconds}")
+    private long validityInSeconds;
+
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private long refreshTokenValidityInSeconds;
+
+    @Value("${jwt.allowed-clock-skew-seconds:60}")
+    private long allowedClockSkewSeconds;
+
+    private JwtParser parser;
+
+    @PostConstruct
+    void init(){
+        this.parser = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .setAllowedClockSkewSeconds(allowedClockSkewSeconds)
+                .requireIssuer(issuer)
+                .build();
+    }
+
+    public String createAccessToken(User user) {
+        Date expiryDate = Date.from(Instant.now().plusSeconds(validityInSeconds));
+        return Jwts.builder()
+                .signWith( SignatureAlgorithm.HS512, secretKey)
+                .setIssuer("beanspot")
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate) // exp
+                .setSubject(user.getId().toString())
+                .claim("email", user.getEmail())
+                .claim("name", user.getNickname())
+                .claim("type", "access")
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        Date expiryDate = Date.from(Instant.now().plusSeconds(validityInSeconds));
+        return Jwts.builder()
+                .signWith( SignatureAlgorithm.HS512, secretKey)
+                .setIssuer("beanspot")
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate) // exp
+                .setSubject(user.getId().toString())
+                .claim("type", "refresh")
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = getAllClaims(token);
+        return Long.parseLong(claims.getSubject());
+
+    }
+
+    public String getTokenType(String token) {
+        Claims claims = getAllClaims(token);
+        Object t = claims.get("type");
+        return t != null ? t.toString() : null;
+    }
+
+    public String getEmailIfPresent(String token) {
+        Claims claims = getAllClaims(token);
+        Object v = claims.get("email");
+        return v != null ? v.toString() : null;
+    }
+
+    private Claims getAllClaims(String token) {
+        return parser.parseClaimsJws(token).getBody();
+    }
+
+    public boolean validateToken(String token){
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰 없거나 잘못되었습니다.");
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/beanspot/backend/security/TokenProvider.java
+++ b/src/main/java/com/beanspot/backend/security/TokenProvider.java
@@ -54,6 +54,21 @@ public class TokenProvider {
                 .compact();
     }
 
+    public String createTemporaryAccessToken(String socialType, String socialId) {
+        Date expiryDate = Date.from(Instant.now().plusSeconds(validityInSeconds));
+        return Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, secretKey)
+                .setIssuer(issuer)
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .setSubject("temporary")
+                .claim("socialId", socialId)
+                .claim("socialType", socialType)
+                .claim("isProfileComplete", false)
+                .claim("type", "temporary")
+                .compact();
+    }
+
     public String createRefreshToken(User user) {
         Date expiryDate = Date.from(Instant.now().plusSeconds(validityInSeconds));
         return Jwts.builder()
@@ -78,10 +93,14 @@ public class TokenProvider {
         return t != null ? t.toString() : null;
     }
 
-    public String getEmailIfPresent(String token) {
+    public String getSocialIdFromToken(String token) {
         Claims claims = getAllClaims(token);
-        Object v = claims.get("email");
-        return v != null ? v.toString() : null;
+        return claims.get("socialId", String.class);
+    }
+
+    public String getSocialTypeFromToken(String token) {
+        Claims claims = getAllClaims(token);
+        return claims.get("socialType", String.class);
     }
 
     private Claims getAllClaims(String token) {

--- a/src/main/java/com/beanspot/backend/security/UserPrincipal.java
+++ b/src/main/java/com/beanspot/backend/security/UserPrincipal.java
@@ -3,15 +3,25 @@ package com.beanspot.backend.security;
 import com.beanspot.backend.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
-public class UserPrincipal implements UserDetails {
+public class UserPrincipal implements UserDetails, OAuth2User {
     private final User user;
+    private Map<String, Object> attributes; // OAuth 제공자로 부터 받은 회원 정보
+    private boolean oauth = false;
 
     public UserPrincipal(User user) {
         this.user = user;
+    }
+
+    public UserPrincipal(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+        this.oauth = true;
     }
 
     public static UserPrincipal create(User user) {
@@ -23,12 +33,18 @@ public class UserPrincipal implements UserDetails {
                         .nickname(user.getNickname())
                         .userId(user.getUserId())
                         .phone(user.getPhone())
+                        .socialId(user.getSocialId())
                         .build()
         );
     }
 
     public static UserPrincipal from(User user) {
         return new UserPrincipal(user);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
     }
 
 
@@ -56,4 +72,9 @@ public class UserPrincipal implements UserDetails {
     }
 
     public String getUserId(){ return user.getUserId(); }
+
+    public String getSocialId(){ return user.getSocialId(); }
+
+    public String getName(){ return user.getName(); }
 }
+

--- a/src/main/java/com/beanspot/backend/security/UserPrincipal.java
+++ b/src/main/java/com/beanspot/backend/security/UserPrincipal.java
@@ -1,6 +1,6 @@
 package com.beanspot.backend.security;
 
-import com.beanspot.backend.domain.User;
+import com.beanspot.backend.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/src/main/java/com/beanspot/backend/security/UserPrincipal.java
+++ b/src/main/java/com/beanspot/backend/security/UserPrincipal.java
@@ -1,0 +1,61 @@
+package com.beanspot.backend.security;
+
+import com.beanspot.backend.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserPrincipal implements UserDetails {
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+    public static UserPrincipal create(User user) {
+        return new UserPrincipal(
+                User.builder()
+                        .id(user.getId())
+                        .name(user.getName())
+                        .password(user.getPassword())
+                        .nickname(user.getNickname())
+                        .email(user.getEmail())
+                        .phone(user.getPhone())
+                        .build()
+        );
+    }
+
+    public static UserPrincipal from(User user) {
+        return new UserPrincipal(user);
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    public Long getId(){
+        return user.getId();
+    }
+
+    public String getNickname(){
+        return user.getNickname();
+    }
+
+    public String getEmail(){
+        return user.getEmail();
+    }
+}

--- a/src/main/java/com/beanspot/backend/security/UserPrincipal.java
+++ b/src/main/java/com/beanspot/backend/security/UserPrincipal.java
@@ -21,7 +21,7 @@ public class UserPrincipal implements UserDetails {
                         .name(user.getName())
                         .password(user.getPassword())
                         .nickname(user.getNickname())
-                        .email(user.getEmail())
+                        .userId(user.getUserId())
                         .phone(user.getPhone())
                         .build()
         );
@@ -55,7 +55,5 @@ public class UserPrincipal implements UserDetails {
         return user.getNickname();
     }
 
-    public String getEmail(){
-        return user.getEmail();
-    }
+    public String getUserId(){ return user.getUserId(); }
 }

--- a/src/main/java/com/beanspot/backend/security/WebSecurityConfig.java
+++ b/src/main/java/com/beanspot/backend/security/WebSecurityConfig.java
@@ -1,0 +1,50 @@
+package com.beanspot.backend.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http
+                .cors(Customizer.withDefaults())
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/",
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/webjars/**").permitAll()
+                        .anyRequest().authenticated()
+
+                ).exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new Http403ForbiddenEntryPoint()));
+
+
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncode(){
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/beanspot/backend/service/AdminReportService.java
+++ b/src/main/java/com/beanspot/backend/service/AdminReportService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class AdminReportService {
+}

--- a/src/main/java/com/beanspot/backend/service/AnnouncementService.java
+++ b/src/main/java/com/beanspot/backend/service/AnnouncementService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class AnnouncementService {
+}

--- a/src/main/java/com/beanspot/backend/service/AnnouncementService.java
+++ b/src/main/java/com/beanspot/backend/service/AnnouncementService.java
@@ -1,2 +1,60 @@
-package com.beanspot.backend.service;public class AnnouncementService {
+package com.beanspot.backend.service;
+
+import com.beanspot.backend.dto.admin.AnnouncementRequestDto;
+import com.beanspot.backend.entity.Announcement;
+import com.beanspot.backend.entity.AnnouncementSchedule;
+import com.beanspot.backend.entity.User;
+import com.beanspot.backend.repository.AnnouncementRepository;
+import com.beanspot.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+    private final AnnouncementRepository announcementRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createAnnouncement(Long adminId, AnnouncementRequestDto dto) {
+        // 1. 관리자 존재 여부 확인
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
+
+        // 2. Announcement 엔티티 생성 (피그마 1, 2단계 데이터)
+        Announcement announcement = Announcement.builder()
+                .title(dto.getTitle())
+                .organizer(dto.getOrganizer())      // 운영 주체
+                .recruitmentCount(dto.getRecruitmentCount())
+                .location(dto.getLocation())
+                .recruitmentStart(LocalDateTime.parse(dto.getRecruitmentStart()))
+                .recruitmentEnd(LocalDateTime.parse(dto.getRecruitmentEnd())) // 글자를 날짜 형식으로 변환해서 넣음                .startDate(dto.getStartDate())
+                .endDate(LocalDateTime.parse(dto.getEndDate()))                .type(dto.getType())
+                .imgUrl(dto.getImgUrl())
+                .linkUrl(dto.getLinkUrl())
+                .content(dto.getContent())          // 상세 내용
+                .closingment(dto.getClosingment())  // 마무리 멘트
+                .viewCount(0)                       // 초기 조회수
+                .build();
+
+        // 3. 세부 일정 처리 (피그마 3단계 데이터 - 1:N 관계)
+        if (dto.getSchedules() != null && !dto.getSchedules().isEmpty()) {
+            dto.getSchedules().forEach(scheduleDto -> {
+                AnnouncementSchedule schedule = AnnouncementSchedule.builder()
+                        .dateInfo(scheduleDto.getDateInfo())
+                        .description(scheduleDto.getDescription())
+                        .build();
+
+                // 연관 관계 편의 메서드를 통해 Announcement와 연결
+                announcement.addSchedule(schedule);
+            });
+        }
+
+        // 4. 저장 (Cascade 설정 덕분에 일정까지 한 번에 저장됩니다)
+        return announcementRepository.save(announcement).getId();
+    }
 }

--- a/src/main/java/com/beanspot/backend/service/AnnouncementService.java
+++ b/src/main/java/com/beanspot/backend/service/AnnouncementService.java
@@ -1,60 +1,51 @@
 package com.beanspot.backend.service;
 
-import com.beanspot.backend.dto.admin.AnnouncementRequestDto;
-import com.beanspot.backend.entity.Announcement;
-import com.beanspot.backend.entity.AnnouncementSchedule;
-import com.beanspot.backend.entity.User;
-import com.beanspot.backend.repository.AnnouncementRepository;
-import com.beanspot.backend.repository.UserRepository;
+import com.beanspot.backend.dto.admin.AnnouncementRequestDto; // 경로 수정
+import com.beanspot.backend.entity.*;
+import com.beanspot.backend.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class AnnouncementService {
+
     private final AnnouncementRepository announcementRepository;
     private final UserRepository userRepository;
 
-    @Transactional
-    public Long createAnnouncement(Long adminId, AnnouncementRequestDto dto) {
-        // 1. 관리자 존재 여부 확인
+    public Long createAnnouncement(AnnouncementRequestDto dto, Long adminId) {
         User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 관리자가 없습니다."));
 
-        // 2. Announcement 엔티티 생성 (피그마 1, 2단계 데이터)
-        Announcement announcement = Announcement.builder()
-                .title(dto.getTitle())
-                .organizer(dto.getOrganizer())      // 운영 주체
-                .recruitmentCount(dto.getRecruitmentCount())
-                .location(dto.getLocation())
-                .recruitmentStart(LocalDateTime.parse(dto.getRecruitmentStart()))
-                .recruitmentEnd(LocalDateTime.parse(dto.getRecruitmentEnd())) // 글자를 날짜 형식으로 변환해서 넣음                .startDate(dto.getStartDate())
-                .endDate(LocalDateTime.parse(dto.getEndDate()))                .type(dto.getType())
-                .imgUrl(dto.getImgUrl())
-                .linkUrl(dto.getLinkUrl())
-                .content(dto.getContent())          // 상세 내용
-                .closingment(dto.getClosingment())  // 마무리 멘트
-                .viewCount(0)                       // 초기 조회수
-                .build();
+        // 1. 유형별 빌더 호출 (모든 엔티티에 @SuperBuilder가 있어야 함)
+        Announcement announcement = switch (dto.getType().toUpperCase()) {
+            case "VOLUNTEER" -> AnnouncementVolunteer.builder()
+                    .isServiceHoursVerified(dto.getIsServiceHoursVerified())
+                    .fee(dto.getFee())
+                    .build();
+            case "CHALLENGE" -> AnnouncementChallenge.builder()
+                    .prizeScale(dto.getPrizeScale())
+                    .participantTarget(dto.getParticipantTarget())
+                    .teamSize(dto.getTeamSize())
+                    .build();
+            // ... 나머지 case 추가
+            default -> throw new IllegalArgumentException("Unknown type");
+        };
 
-        // 3. 세부 일정 처리 (피그마 3단계 데이터 - 1:N 관계)
-        if (dto.getSchedules() != null && !dto.getSchedules().isEmpty()) {
-            dto.getSchedules().forEach(scheduleDto -> {
-                AnnouncementSchedule schedule = AnnouncementSchedule.builder()
-                        .dateInfo(scheduleDto.getDateInfo())
-                        .description(scheduleDto.getDescription())
-                        .build();
+        // 2. 공통 필드 설정 (부모 엔티티에 @Setter 필요)
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-                // 연관 관계 편의 메서드를 통해 Announcement와 연결
-                announcement.addSchedule(schedule);
-            });
-        }
+        announcement.setAdmin(admin);
+        announcement.setTitle(dto.getTitle());
+        announcement.setContent(dto.getContent());
+        announcement.setOrganizer(dto.getOrganizer());
+        announcement.setRecruitmentStart(LocalDateTime.parse(dto.getRecruitmentStart(), formatter));
+        // ... 나머지 날짜 및 공통 필드 세팅
 
-        // 4. 저장 (Cascade 설정 덕분에 일정까지 한 번에 저장됩니다)
         return announcementRepository.save(announcement).getId();
     }
 }

--- a/src/main/java/com/beanspot/backend/service/CalendarService.java
+++ b/src/main/java/com/beanspot/backend/service/CalendarService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class CalendarService {
+}

--- a/src/main/java/com/beanspot/backend/service/DiaryService.java
+++ b/src/main/java/com/beanspot/backend/service/DiaryService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class DiaryService {
+}

--- a/src/main/java/com/beanspot/backend/service/FeedbackService.java
+++ b/src/main/java/com/beanspot/backend/service/FeedbackService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class FeedbackService {
+}

--- a/src/main/java/com/beanspot/backend/service/KakaoLoginService.java
+++ b/src/main/java/com/beanspot/backend/service/KakaoLoginService.java
@@ -1,0 +1,7 @@
+package com.beanspot.backend.service;
+
+import com.beanspot.backend.oauth.KakaoInfo;
+
+public interface KakaoLoginService {
+    KakaoInfo kakaoLogin(final String code, final String redirectUrl);
+}

--- a/src/main/java/com/beanspot/backend/service/KakaoLoginServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/KakaoLoginServiceImpl.java
@@ -1,0 +1,109 @@
+package com.beanspot.backend.service;
+
+import com.beanspot.backend.oauth.KakaoInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoLoginServiceImpl implements KakaoLoginService {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoLoginServiceImpl.class);
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    public KakaoInfo kakaoLogin(String code, String redirectUrl){
+        String accessToken = getAccessToken(code, redirectUrl);
+        return getKakaoUserInfo(accessToken);
+    }
+
+    private String getAccessToken(String code, String redirectUrl){
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8 ");
+
+        log.info("clientId: " + clientId);
+        log.info("redirectUrl: " + redirectUrl);
+
+        // BODY 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUrl);
+        body.add("code", code);
+
+        //요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        //HTTP 응답 -> 액세스 토큰 파싱
+        String responseBody = response.getBody();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode json = null;
+        try {
+            json = mapper.readTree(responseBody);
+        }catch (JsonProcessingException e){
+            e.printStackTrace();
+        }
+
+        return json.get("access_token").asText();
+
+    }
+
+    private KakaoInfo getKakaoUserInfo(String accessToken){
+        HashMap<String, Object> userInfo = new HashMap<String, Object>();
+
+        //HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        String responseBody = response.getBody();
+        ObjectMapper mapper = new ObjectMapper();
+        KakaoInfo kakaoInfo = null;
+
+        try{
+            Map<String, Object> attributes = mapper.readValue(responseBody, Map.class);
+            kakaoInfo = new KakaoInfo(attributes);
+
+        }catch (JsonProcessingException e){
+            e.printStackTrace();
+        }
+        return kakaoInfo;
+    }
+}

--- a/src/main/java/com/beanspot/backend/service/NoticeService.java
+++ b/src/main/java/com/beanspot/backend/service/NoticeService.java
@@ -1,0 +1,2 @@
+package com.beanspot.backend.service;public class NoticeService {
+}

--- a/src/main/java/com/beanspot/backend/service/TodoService.java
+++ b/src/main/java/com/beanspot/backend/service/TodoService.java
@@ -1,0 +1,84 @@
+package com.beanspot.backend.service;
+
+import com.beanspot.backend.dto.user.TodoRequestDto;
+import com.beanspot.backend.dto.user.TodoResponseDto;
+import com.beanspot.backend.entity.Todo;
+import com.beanspot.backend.entity.User;
+import com.beanspot.backend.repository.TodoRepository;
+import com.beanspot.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 특정 날짜의 투두 리스트 조회
+     */
+    public List<TodoResponseDto> getDailyTodos(Long userId, LocalDate date) {
+        // Repository에서 UserId와 날짜로 조회 (이름 주의: ByUserIdAndDate)
+        return todoRepository.findAllByUserIdAndDate(userId, date)
+                .stream()
+                .map(TodoResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 새로운 투두 추가
+     */
+    @Transactional
+    public Long addTodo(Long userId, TodoRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Todo todo = Todo.builder()
+                .content(dto.getContent())
+                .date(dto.getDate())
+                .isCompleted(false) // 기본값은 미완료
+                .user(user)
+                .build();
+
+        return todoRepository.save(todo).getId();
+    }
+
+    /**
+     * 투두 상태 변경 (완료/미완료 토글)
+     */
+    @Transactional
+    public void toggleStatus(Long userId, Long todoId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 할 일이 없습니다."));
+
+        // 본인 확인 보안 체크
+        if (!todo.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("해당 기능에 대한 권한이 없습니다.");
+        }
+
+        todo.toggle(); // 엔티티의 토글 메서드 호출
+    }
+
+    /**
+     * 투두 삭제
+     */
+    @Transactional
+    public void deleteTodo(Long userId, Long todoId) {
+        Todo todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 할 일이 없습니다."));
+
+        if (!todo.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("삭제 권한이 없습니다.");
+        }
+
+        todoRepository.delete(todo);
+    }
+}

--- a/src/main/java/com/beanspot/backend/service/UserService.java
+++ b/src/main/java/com/beanspot/backend/service/UserService.java
@@ -1,5 +1,9 @@
 package com.beanspot.backend.service;
 
+import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.entity.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 public interface UserService {
     SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO);
     User getByCredential(final String email, final String password, PasswordEncoder encoder);

--- a/src/main/java/com/beanspot/backend/service/UserService.java
+++ b/src/main/java/com/beanspot/backend/service/UserService.java
@@ -1,12 +1,18 @@
 package com.beanspot.backend.service;
 
+import com.beanspot.backend.dto.auth.LoginUserDTO;
+import com.beanspot.backend.dto.auth.SignUpSocialUserDTO;
 import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.dto.user.UserProfileDTO;
 import com.beanspot.backend.entity.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public interface UserService {
     SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO);
     User getByCredential(final String email, final String password, PasswordEncoder encoder);
+    LoginUserDTO.Res login(LoginUserDTO.Req userDTO, PasswordEncoder encoder);
     boolean isNicknameAvailable(final String nickname);
-    User getUserProfileById(final Long id);
+    UserProfileDTO getUserProfileById(final Long id);
+    SignUpSocialUserDTO.Res createSocialUser(final String socialId, final SignUpSocialUserDTO.Req userDTO);
+    LoginUserDTO.Res loginBySocialId(final String socialType, final String socialId);
 }

--- a/src/main/java/com/beanspot/backend/service/UserService.java
+++ b/src/main/java/com/beanspot/backend/service/UserService.java
@@ -1,0 +1,8 @@
+package com.beanspot.backend.service;
+
+public interface UserService {
+    SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO);
+    User getByCredential(final String email, final String password, PasswordEncoder encoder);
+    boolean isNicknameAvailable(final String nickname);
+    User getUserProfileById(final Long id);
+}

--- a/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
@@ -2,9 +2,8 @@ package com.beanspot.backend.service;
 
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
-import com.beanspot.backend.domain.SocialType;
-import com.beanspot.backend.domain.User;
 import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.entity.User;
 import com.beanspot.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +41,7 @@ public class UserServiceImpl implements UserService {
                 .password(passwordEncoder.encode(userDTO.getPassword()))
                 .nickname(userDTO.getNickname())
                 .name(userDTO.getName())
-                .socialType(SocialType.NONE)
+                .socialType(com.beanspot.backend.entity.SocialType.NONE)
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
@@ -2,14 +2,21 @@ package com.beanspot.backend.service;
 
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
+import com.beanspot.backend.dto.auth.LoginUserDTO;
+import com.beanspot.backend.dto.auth.SignUpSocialUserDTO;
 import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.dto.user.UserProfileDTO;
+import com.beanspot.backend.entity.SocialType;
 import com.beanspot.backend.entity.User;
 import com.beanspot.backend.repository.UserRepository;
+import com.beanspot.backend.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -20,6 +27,9 @@ public class UserServiceImpl implements UserService {
     private UserRepository userRepository;
 
     private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private TokenProvider tokenProvider;
 
     public SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO) {
 
@@ -62,13 +72,88 @@ public class UserServiceImpl implements UserService {
         return user;
     }
 
+    public LoginUserDTO.Res login(LoginUserDTO.Req userDTO, PasswordEncoder encoder) {
+        User user = userRepository.findByUserId(userDTO.getUserId())
+                .orElseThrow(()-> new CustomException(ErrorCode.AUTH_EMAIL_NOT_FOUND));
+        if(!encoder.matches(userDTO.getPassword(), user.getPassword())){
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_MISMATCH);
+        }
+        final String accessToken = tokenProvider.createAccessToken(user);
+
+        LoginUserDTO.Res reponseUserDTO = LoginUserDTO.Res.builder()
+                .accessToken(accessToken)
+                .nickname(user.getNickname())
+                .id(user.getId())
+                .build();
+        return reponseUserDTO;
+    }
+
     public boolean isNicknameAvailable(final String nickname) {
         return !userRepository.existsByNickname(nickname);
     }
 
     @Override
-    public User getUserProfileById(Long id) {
-        return userRepository.findById(id)
+    public UserProfileDTO getUserProfileById(Long id) {
+        User user = userRepository.findById(id)
                 .orElseThrow(()-> new CustomException(ErrorCode.AUTH_LOGIN_REQUIRED));
+
+        return UserProfileDTO.builder()
+                .id(user.getId())
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .name(user.getName())
+                .socialId(user.getSocialId())
+                .socialType(user.getSocialType())
+                .build();
     }
+    public LoginUserDTO.Res loginBySocialId(String socialType, String socialId) {
+        Optional<User> user = userRepository.findBySocialId(socialId);
+
+        if(user.isPresent()){
+            String accessToken = tokenProvider.createAccessToken(user.get());
+            return LoginUserDTO.Res.builder()
+                    .accessToken(accessToken)
+                    .nickname(user.get().getNickname())
+                    .id(user.get().getId())
+                    .isProfileComplete(true)
+                    .build();
+        }else{
+            String tempToken = tokenProvider.createTemporaryAccessToken(socialType, socialId);
+            return LoginUserDTO.Res.builder()
+                    .accessToken(tempToken)
+                    .isProfileComplete(false)
+                    .build();
+        }
+
+    }
+
+    //소셜 회원 추가 정보 입력 절차
+    public SignUpSocialUserDTO.Res createSocialUser(String socialId, SignUpSocialUserDTO.Req userDTO) {
+        final String nickname = userDTO.getNickname();
+
+        if(userRepository.existsByUserId(socialId)){
+            log.warn("User with userId {} already exists", socialId);
+            throw new CustomException(ErrorCode.AUTH_SOCIAL_ID_ALREADY_EXISTS);
+        }
+
+        if(!isNicknameAvailable(nickname)){
+            log.warn("User with nickname {} already exists", nickname);
+            throw new CustomException(ErrorCode.AUTH_NICKNAME_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .nickname(userDTO.getNickname())
+                .name(userDTO.getUserName())
+                .socialType(SocialType.KAKAO)
+                .socialId(socialId)
+                .build();
+
+        userRepository.save(user);
+
+        return  SignUpSocialUserDTO.Res.builder()
+                .socialId(user.getSocialId())
+                .nickname(user.getNickname())
+                .build();
+    }
+
 }

--- a/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
@@ -1,0 +1,75 @@
+package com.beanspot.backend.service;
+
+import com.beanspot.backend.common.exception.CustomException;
+import com.beanspot.backend.common.exception.ErrorCode;
+import com.beanspot.backend.domain.SocialType;
+import com.beanspot.backend.domain.User;
+import com.beanspot.backend.dto.auth.SignUpUserDTO;
+import com.beanspot.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    public SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO) {
+
+        final String email = userDTO.getEmail();
+        final String nickname = userDTO.getNickname();
+
+        if(userRepository.existsByEmail(email)){
+            log.warn("User with email {} already exists", email);
+            throw new CustomException(ErrorCode.AUTH_USERID_ALREADY_EXISTS);
+        }
+
+        if(!isNicknameAvailable(nickname)){
+            log.warn("User with nickname {} already exists", nickname);
+            throw new CustomException(ErrorCode.AUTH_NICKNAME_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .email(userDTO.getEmail())
+                .password(passwordEncoder.encode(userDTO.getPassword()))
+                .nickname(userDTO.getNickname())
+                .name(userDTO.getName())
+                .socialType(SocialType.NONE)
+                .build();
+
+        userRepository.save(user);
+
+        return  SignUpUserDTO.Res.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+
+    }
+
+    public User getByCredential(final String email, final String password, PasswordEncoder encoder) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new CustomException(ErrorCode.AUTH_EMAIL_NOT_FOUND));
+        if(!encoder.matches(password, user.getPassword())){
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_MISMATCH);
+        }
+        return user;
+    }
+
+    public boolean isNicknameAvailable(final String nickname) {
+        return !userRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public User getUserProfileById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(()-> new CustomException(ErrorCode.AUTH_LOGIN_REQUIRED));
+    }
+}

--- a/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/UserServiceImpl.java
@@ -23,11 +23,11 @@ public class UserServiceImpl implements UserService {
 
     public SignUpUserDTO.Res createUser(final SignUpUserDTO.Req userDTO) {
 
-        final String email = userDTO.getEmail();
+        final String userId = userDTO.getUserId();
         final String nickname = userDTO.getNickname();
 
-        if(userRepository.existsByEmail(email)){
-            log.warn("User with email {} already exists", email);
+        if(userRepository.existsByUserId(userId)){
+            log.warn("User with userId {} already exists", userId);
             throw new CustomException(ErrorCode.AUTH_USERID_ALREADY_EXISTS);
         }
 
@@ -37,7 +37,7 @@ public class UserServiceImpl implements UserService {
         }
 
         User user = User.builder()
-                .email(userDTO.getEmail())
+                .userId(userDTO.getUserId())
                 .password(passwordEncoder.encode(userDTO.getPassword()))
                 .nickname(userDTO.getNickname())
                 .name(userDTO.getName())
@@ -47,14 +47,14 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
 
         return  SignUpUserDTO.Res.builder()
-                .email(user.getEmail())
+                .userId(userDTO.getUserId())
                 .nickname(user.getNickname())
                 .build();
 
     }
 
-    public User getByCredential(final String email, final String password, PasswordEncoder encoder) {
-        User user = userRepository.findByEmail(email)
+    public User getByCredential(final String userId, final String password, PasswordEncoder encoder) {
+        User user = userRepository.findByUserId(userId)
                 .orElseThrow(()-> new CustomException(ErrorCode.AUTH_EMAIL_NOT_FOUND));
         if(!encoder.matches(password, user.getPassword())){
             throw new CustomException(ErrorCode.AUTH_PASSWORD_MISMATCH);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,0 @@
-# src/main/resources/application.yml
-spring:
-  profiles:
-    active: dev
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+# src/main/resources/application.yml
+spring:
+  profiles:
+    active: dev


### PR DESCRIPTION
주요 구현 기능
캘린더 도메인의 핵심인 일기(Diary) CRUD API를 명세서에 맞춰 구현하고 로컬 테스트를 완료
일기 작성/수정: 날짜, 본문, 감정, 캐릭터를 포함한 일기 데이터를 저장
일기 목록 조회: 연/월 파라미터를 받아 해당 월의 일기 목록을 반환
일기 상세 조회: 특정 일기의 상세 내용을 조회
일기 삭제: 작성된 일기를 삭제

Diary.java	일기 데이터를 DB 테이블과 매핑하는 Entity 클래스
CharacterType.java	캐릭터 종류(GREEN, BROWN)를 정의하는 Enum
EmotionType.java	일기 감정 상태를 정의하는 Enum
DiaryController.java	일기 관련 HTTP 요청을 받아 해당 서비스로 연결하는 Controller
DiaryRepository.java	DB에 접근하여 일기 데이터를 CRUD 하는 Repository 인터페이스
DiaryRequestDto.java	클라이언트로부터 입력받은 일기 데이터를 전달하는 DTO
DiaryResponseDto.java	API 응답 시 일기 정보를 담아 전달하는 DTO
WebSecurityConfig.java	일기 API 접근 권한(ROLE_USER) 설정 및 순서 오류를 수정한 Security 설정 파일

Closes #17