### PR TITLE
feat: 일기 CRUD API 구현  #17

### DIFF
--- a/src/main/java/com/beanspot/backend/controller/DiaryController.java
+++ b/src/main/java/com/beanspot/backend/controller/DiaryController.java
@@ -1,2 +1,69 @@
-package com.beanspot.backend.controller;public class DiaryController {
+package com.beanspot.backend.controller;
+
+import com.beanspot.backend.dto.user.DiaryRequestDto;
+import com.beanspot.backend.dto.user.DiaryResponseDto;
+import com.beanspot.backend.security.CurrentUser;
+import com.beanspot.backend.security.UserPrincipal;
+import com.beanspot.backend.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Diary", description = "일기 관련 API")
+@RestController
+@RequestMapping("/api/v1/diaries") // 명세서 규격에 맞춰 경로 수정
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @Operation(summary = "일기 작성", description = "새로운 일기를 작성합니다.")
+    @PostMapping
+    public ResponseEntity<Long> create(@CurrentUser UserPrincipal userPrincipal,
+                                       @RequestBody DiaryRequestDto dto) {
+        Long diaryId = diaryService.saveDiary(userPrincipal.getId(), dto);
+        return ResponseEntity.ok(diaryId);
+    }
+
+    @Operation(summary = "월별 일기 목록 조회", description = "특정 연도와 월의 일기 목록을 가져옵니다.")
+    @GetMapping
+    public ResponseEntity<List<DiaryResponseDto>> getMonthlyDiaries(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam int year,
+            @RequestParam int month) {
+        // 명세서: GET /api/v1/diaries?year=2025&month=12
+        List<DiaryResponseDto> diaries = diaryService.getMonthlyDiaries(userPrincipal.getId(), year, month);
+        return ResponseEntity.ok(diaries);
+    }
+
+    @Operation(summary = "일기 상세 조회", description = "특정 ID의 일기 상세 내용을 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<DiaryResponseDto> getDetail(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long id) {
+        // 명세서: GET /api/v1/diaries/{diaryId}
+        DiaryResponseDto diary = diaryService.getDiaryDetail(userPrincipal.getId(), id);
+        return ResponseEntity.ok(diary);
+    }
+
+    @Operation(summary = "일기 수정", description = "기존에 작성한 일기를 수정합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@CurrentUser UserPrincipal userPrincipal,
+                                       @PathVariable Long id,
+                                       @RequestBody DiaryRequestDto dto) {
+        diaryService.updateDiary(userPrincipal.getId(), id, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@CurrentUser UserPrincipal userPrincipal,
+                                       @PathVariable Long id) {
+        diaryService.deleteDiary(userPrincipal.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryRequestDto.java
@@ -1,2 +1,28 @@
-package com.beanspot.backend.dto.user;public class DiaryRequestDto {
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.entity.CharacterType;
+import com.beanspot.backend.entity.EmotionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryRequestDto {
+
+    @Schema(description = "일기 작성 날짜", example = "2026-01-30")
+    private LocalDate date;
+
+    @Schema(description = "캐릭터 타입 (GREEN: 푸웅, BROWN: 꾸웅)", example = "GREEN")
+    private CharacterType characterType;
+
+    @Schema(description = "감정 타입 (HAPPY, SAD, ANGRY 등)", example = "HAPPY")
+    private EmotionType emotionType;
+
+    @Schema(description = "일기 내용 (최대 200자)", example = "오늘은 스프링 부트 설정을 마쳤다. 뿌듯하다!")
+    private String content;
 }

--- a/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
+++ b/src/main/java/com/beanspot/backend/dto/user/DiaryResponseDto.java
@@ -1,2 +1,48 @@
-package com.beanspot.backend.dto.user;public class DiaryResponseDto {
+package com.beanspot.backend.dto.user;
+
+import com.beanspot.backend.entity.CharacterType;
+import com.beanspot.backend.entity.Diary;
+import com.beanspot.backend.entity.EmotionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryResponseDto {
+
+    @Schema(description = "일기 ID (고유 번호)", example = "1")
+    private Long id;
+
+    @Schema(description = "일기 작성 날짜", example = "2026-01-30")
+    private LocalDate date;
+
+    @Schema(description = "캐릭터 타입", example = "GREEN")
+    private CharacterType characterType;
+
+    @Schema(description = "감정 타입", example = "HAPPY")
+    private EmotionType emotionType;
+
+    @Schema(description = "일기 내용", example = "오늘은 스프링 부트 기능을 완성했다!")
+    private String content;
+
+    /**
+     * Entity -> DTO 변환 메서드
+     * 서비스 계층에서 DB 데이터를 DTO로 편하게 바꾸기 위해 사용합니다.
+     */
+    public static DiaryResponseDto from(Diary diary) {
+        return DiaryResponseDto.builder()
+                .id(diary.getId())
+                .date(diary.getDate())
+                .characterType(diary.getCharacterType())
+                .emotionType(diary.getEmotionType())
+                .content(diary.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/beanspot/backend/entity/CharacterType.java
+++ b/src/main/java/com/beanspot/backend/entity/CharacterType.java
@@ -1,2 +1,3 @@
-package com.beanspot.backend.entity;public class CharacterType {
-}
+package com.beanspot.backend.entity;
+
+public enum CharacterType { GREEN, BROWN }

--- a/src/main/java/com/beanspot/backend/entity/Diary.java
+++ b/src/main/java/com/beanspot/backend/entity/Diary.java
@@ -1,2 +1,47 @@
-package com.beanspot.backend.entity;public class Diary {
+package com.beanspot.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate date;
+
+    @Enumerated(EnumType.STRING)
+    private CharacterType characterType; // GREEN(푸웅), BROWN(꾸웅)
+
+    @Enumerated(EnumType.STRING)
+    private EmotionType emotionType;     // HAPPY, SAD, ANGRY 등 6종
+
+    @Column(length = 200)
+    private String content; // 최대 200자
+
+    @Builder
+    public Diary(User user, LocalDate date, CharacterType characterType, EmotionType emotionType, String content) {
+        this.user = user;
+        this.date = date;
+        this.characterType = characterType;
+        this.emotionType = emotionType;
+        this.content = content;
+    }
+
+    // Diary.java 엔터티 내부에 추가
+    public void update(LocalDate date, CharacterType characterType, EmotionType emotionType, String content) {
+        this.date = date;
+        this.characterType = characterType;
+        this.emotionType = emotionType;
+        this.content = content;
+    }
 }
+

--- a/src/main/java/com/beanspot/backend/entity/EmotionType.java
+++ b/src/main/java/com/beanspot/backend/entity/EmotionType.java
@@ -1,2 +1,4 @@
-package com.beanspot.backend.entity;public class EmotionType {
-}
+package com.beanspot.backend.entity;
+
+public enum EmotionType { HAPPY, ANGRY, SAD, SURPRISED, CALM, TIRED }
+

--- a/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/DiaryRepository.java
@@ -1,2 +1,25 @@
-package com.beanspot.backend.repository;public class DiaryRepository {
+package com.beanspot.backend.repository;
+
+import com.beanspot.backend.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional; // Optional을 사용해야 orElse(null)을 쓸 수 있습니다.
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    /**
+     * 특정 사용자의 특정 기간(한 달) 동안의 일기 목록을 조회합니다.
+     * 캘린더에 일기 아이콘을 표시할 때 사용합니다.
+     */
+    List<Diary> findAllByUserIdAndDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+
+    // [일별 상세 조회] 이번에 추가해야 할 메서드
+    Optional<Diary> findByUserIdAndDate(Long memberId, LocalDate date);
+
+
+
+
 }


### PR DESCRIPTION
develop 에 다시 pr
### 주요 구현 기능
- 캘린더 도메인의 핵심인 일기(Diary) CRUD API를 명세서에 맞춰 구현하고 로컬 테스트를 완료했습니다.
- 일기 작성/수정, 목록 조회, 상세 조회, 삭제 기능 포함

### 파일별 역할
- Diary.java: 일기 데이터 엔티티
- CharacterType.java / EmotionType.java: 캐릭터 및 감정 Enum
- DiaryController.java: HTTP 요청 처리
- DiaryRepository.java: DB 접근 인터페이스
- DiaryRequestDto.java / DiaryResponseDto.java: 데이터 전달 객체
- WebSecurityConfig.java: 권한(ROLE_USER) 설정 및 순서 오류 수정

Closes #17