### PR TITLE
feat: 공고 등록 시 이미지 S3 업로드 기능 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'co.elastic.clients:elasticsearch-java'
 
+    //AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'commons-io:commons-io:2.11.0'
+
 }
 
 

--- a/src/main/java/com/beanspot/backend/config/S3Config.java
+++ b/src/main/java/com/beanspot/backend/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.beanspot.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    @Primary
+    public AmazonS3 amazonS3Client() {
+        // AWS 인증 정보 설정
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        // AmazonS3 클라이언트 빌드 및 반환
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/beanspot/backend/controller/AdminAnnouncementController.java
+++ b/src/main/java/com/beanspot/backend/controller/AdminAnnouncementController.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -34,9 +36,12 @@ public class AdminAnnouncementController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 없음")
     })
-    @PostMapping()
-    public ApiResponse<String> createAnnouncement(@RequestBody AnnouncementDTO.Create request) {
-        announcementService.addAnnouncement(request);
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ApiResponse<String> createAnnouncement(
+            @RequestPart("request") AnnouncementDTO.Create request,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        announcementService.addAnnouncement(request, image);
         return ApiResponse.ok("공고 등록");
     }
     @ApiResponses({

--- a/src/main/java/com/beanspot/backend/controller/AnnouncementController.java
+++ b/src/main/java/com/beanspot/backend/controller/AnnouncementController.java
@@ -60,7 +60,7 @@ public class AnnouncementController {
             @RequestParam(required = false) String keyword,
             @Parameter(
                     description = "공고 유형",
-                    example = "SUPPORT"
+                    example = "SUPPORTER"
             )
             @RequestParam(required = false) AnnouncementType type,
 

--- a/src/main/java/com/beanspot/backend/service/S3Service.java
+++ b/src/main/java/com/beanspot/backend/service/S3Service.java
@@ -1,0 +1,87 @@
+package com.beanspot.backend.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file) {
+        String fileName = createFileName(file.getOriginalFilename());
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다.");
+        }
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    public String uploadFromUrl(String imgUrl) {
+        try {
+            URL url = new URL(imgUrl);
+            URLConnection connection = url.openConnection();
+
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+
+            String contentType = connection.getContentType();
+            long contentLength = connection.getContentLengthLong();
+
+            String fileName = "announcement/" + UUID.randomUUID() + ".jpg";
+
+
+            try(InputStream inputStream = connection.getInputStream()) {
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentType(contentType);
+                if( contentLength > 0) metadata.setContentLength(contentLength);
+
+                amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+            }
+
+            return amazonS3.getUrl(bucket, fileName).toString();
+        } catch (IOException e) {
+            log.error("이미지 URL 업로드 실패: {}", e.getMessage());
+            throw new RuntimeException("외부 이미지 가져오기 실패");
+        }
+
+    }
+    // 고유한 파일명 생성
+    private String createFileName(String originalFileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(originalFileName));
+    }
+
+    // 확장자 추출
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            return ".jpg"; // 기본값
+        }
+    }
+}

--- a/src/main/java/com/beanspot/backend/service/announcement/AnnouncementService.java
+++ b/src/main/java/com/beanspot/backend/service/announcement/AnnouncementService.java
@@ -4,6 +4,7 @@ import com.beanspot.backend.common.response.PageResponse;
 import com.beanspot.backend.dto.announcement.AnnouncementDTO;
 import com.beanspot.backend.dto.announcement.AnnouncementSearchConditionDTO;
 import com.beanspot.backend.dto.announcement.AnnouncementSummaryDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 
 public interface AnnouncementService {
@@ -13,7 +14,7 @@ public interface AnnouncementService {
 
     void increaseViewCount(Long id);
 
-    void addAnnouncement(AnnouncementDTO.Create announcement);
+    void addAnnouncement(AnnouncementDTO.Create announcement, MultipartFile image);
 
     void updateAnnouncement(Long id, AnnouncementDTO.Update announcement);
 

--- a/src/main/java/com/beanspot/backend/service/announcement/AnnouncementServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/announcement/AnnouncementServiceImpl.java
@@ -6,11 +6,13 @@ import com.beanspot.backend.entity.announcement.*;
 import com.beanspot.backend.listener.AnnouncementCreatedEvent;
 import com.beanspot.backend.repository.announcement.AnnouncementRepository;
 import com.beanspot.backend.service.KakaoGeoCodingService;
+import com.beanspot.backend.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
    private final ApplicationEventPublisher applicationEventPublisher;
+    private final S3Service s3Service;
 
     @Override
     @Transactional(readOnly = true)
@@ -51,14 +54,21 @@ public class AnnouncementServiceImpl implements AnnouncementService {
 
     @Override
     @Transactional
-    public void addAnnouncement(AnnouncementDTO.Create reqDTO) {
+    public void addAnnouncement(AnnouncementDTO.Create reqDTO, MultipartFile image) {
 
         validateType(reqDTO);
 
+        String uploadedImgUrl = null;
 
+        if(image != null && !image.isEmpty()) {
+            uploadedImgUrl = s3Service.uploadFile(image);
+        }else{
+            uploadedImgUrl = s3Service.uploadFromUrl(reqDTO.getImgUrl());
+        }
+
+        // 주소 -> 위경도 변환 로직
         Double lat = null;
         Double lng = null;
-
         try {
             GeoPoint geo = geoCodingService.convert(reqDTO.getLocation());
             lat = geo.getLat();
@@ -73,7 +83,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
                 .content(reqDTO.getContent())
                 .type(reqDTO.getType())
                 .organizer(reqDTO.getOrganizer())
-                .imgUrl(reqDTO.getImgUrl())
+                .imgUrl(uploadedImgUrl)
                 .region(reqDTO.getRegion())
                 .location(reqDTO.getLocation())
                 .startDate(reqDTO.getStartDate())


### PR DESCRIPTION
## 📌 개요
관리자 공고 등록 시 이미지 처리 방식을 고도화했습니다. 이미지 파일을 직접 업로드하거나, 외부 이미지 URL을 입력하면 해당 이미지를 읽어 beanspot S3 버킷에 사본을 자동으로 생성하는 기능을 추가했습니다.

## 🔍 주요 작업 내용
1. **AWS S3 인프라 구축 및 설정**
**의존성 추가**: AWS SDK S3 사용을 위한 관련 라이브러리를 build.gradle에 추가했습니다.
**S3Config**: AmazonS3Client를 빈으로 등록하여 프로젝트 전역에서 S3 접근이 가능하도록 설정했습니다.

2. **공통 S3 서비스(S3Service) 구현**
**파일 업로드**: MultipartFile을 전달받아 S3의 특정 경로에 업로드하고 접근 가능한 URL을 반환합니다.
**URL 기반 업로드**: 외부 이미지 URL을 입력받아 서버에서 스트림으로 읽은 후, S3에 직접 업로드하여 저장하는 로직을 구현했습니다. 이를 통해 외부 링크 만료로 인한 이미지 유실 문제를 방지합니다.

3. **공고 등록 로직 (AdminAnnouncementController)**
**Multipart 요청 처리**: 공고 정보(JSON)와 이미지 파일(MultipartFile)을 동시에 처리할 수 있도록 컨트롤러 구조를 변경했습니다.


## 🛠️ 참고 사항
**환경 변수**: S3 접근을 위해 .env 파일에 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_BUCKET_NAME 설정이 필요합니다. 

**테스트 완료**: Postman을 통해 파일 업로드 및 URL 복사 기능이 정상 작동함을 확인했습니다.