### PR TITLE
refactor: 공고 데이터 구조 및 서비스 로직 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ es-data/
 ### OS ###
 .DS_Store
 Thumbs.db
+
+# Docker 로컬 설정 파일 제외
+docker-compose.dev.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       retries: 5
     networks:
       - backend
-      -
+
   elasticsearch:
     image: 258143933136.dkr.ecr.ap-northeast-2.amazonaws.com/beanspot-app/beanspot-elasticsearch:latest
     container_name: elasticsearch

--- a/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/beanspot/backend/common/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // ==================== Common (10xxx) ====================
     INVALID_INPUT_VALUE(10001, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    INVALID_LOCATION_FORMAT(10002, HttpStatus.BAD_REQUEST, "위치 정보가 올바르지 않습니다."),
 
     CALENDAR_SCHEDULE_NOT_FOUND(11001, HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
     CALENDAR_INVALID_REPEAT_RULE(11002, HttpStatus.BAD_REQUEST, "유효하지 않은 반복 주기입니다."),
@@ -34,6 +35,9 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(90000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
 
+
+    // ==================== ANNOUNCEMENT (31xxx) ====================
+    ANNOUNCEMENT_NOT_FOUND(31001, HttpStatus.NOT_FOUND, "해당 공고를 찾을 수 없습니다."),
     ;
 
 

--- a/src/main/java/com/beanspot/backend/controller/AnnouncementController.java
+++ b/src/main/java/com/beanspot/backend/controller/AnnouncementController.java
@@ -52,35 +52,25 @@ public class AnnouncementController {
     public PageResponse<AnnouncementSummaryDTO> getAnnouncements(
             @Parameter(hidden = true)
             @CurrentUserId Long userId,
-            @Parameter(
-                    description = "검색 키워드",
-                    example = "플로깅"
-            )
 
+            @Parameter(description = "검색 키워드",example = "플로깅")
             @RequestParam(required = false) String keyword,
-            @Parameter(
-                    description = "공고 유형",
-                    example = "SUPPORT"
-            )
+
+            @Parameter(description = "공고 유형", example = "SUPPORTER")
             @RequestParam(required = false) AnnouncementType type,
 
             @RequestParam(required = false) List<String> hashtags,
 
-            @Parameter(
-                    description = "지역",
-                    example = "강남구"
-            )
+            @Parameter(description = "행정구", example = "강남구")
             @RequestParam(required = false) String region,
-            @Parameter(
-                    description = "모집 기간 (yyyy-MM)",
-                    example = "2026-03"
-            )
+
+            @Parameter(description = "활동 방식 (온라인 / 오프라인)", example = "오프라인")
+            @RequestParam(required = false) String activityMethod,
+
+            @Parameter(description = "모집 기간 (yyyy-MM)", example = "2026-03")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth recruitmentMonth,
 
-            @Parameter(
-                    description = "활동 기간 (yyyy-MM)",
-                    example = "2026-04"
-            )
+            @Parameter(description = "활동 기간 (yyyy-MM)", example = "2026-04")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth activityMonth,
 
             @Parameter(description = "최소 위도", example = "37.4")
@@ -109,6 +99,7 @@ public class AnnouncementController {
                 .type(type)
                 .hashtags(hashtags)
                 .region(region)
+                .activityMethod(activityMethod)
                 .recruitmentMonth(recruitmentMonth)
                 .activityMonth(activityMonth)
                 .minLat(minLat)
@@ -120,6 +111,7 @@ public class AnnouncementController {
                 .page(page)
                 .size(size)
                 .build();
+
         //최근 검색어 저장
         String normalizedKeyword = keyword == null ? null : keyword.trim();
         if(userId != null && StringUtils.hasText(normalizedKeyword)) {

--- a/src/main/java/com/beanspot/backend/controller/AuthController.java
+++ b/src/main/java/com/beanspot/backend/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
     public ApiResponse<?> signup(@RequestBody SignUpUserDTO.Req userDTO) {
 
         if (userDTO == null || userDTO.getPassword() == null) {
-            throw new RuntimeException("Invalid password value.");
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
         SignUpUserDTO.Res responseUserDTO = userService.createUser(userDTO);
         return ApiResponse.ok(responseUserDTO);

--- a/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementDTO.java
@@ -4,11 +4,11 @@ import com.beanspot.backend.entity.announcement.Announcement;
 import com.beanspot.backend.entity.announcement.AnnouncementType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class AnnouncementDTO {
 
@@ -20,6 +20,12 @@ public class AnnouncementDTO {
         private String title;
         private String content;
         private String organizer;
+        private String organizerImgUrl;
+        private String target;
+        private String recruitmentCount;
+        private String activityMethod;
+        private String applyMethod;
+        private String benefits;
         private AnnouncementType type;
         private String imgUrl;
 
@@ -40,21 +46,38 @@ public class AnnouncementDTO {
 
         private Integer fee;
         private int viewCount;
-        private String scheduleDetail;
         private String linkUrl;
         private String serviceHoursVerified;
         private String selectionProcess;
         private String teamSize;
         private String awardScale;
 
+        private List<ScheduleResponseDTO> schedules;
+
+        private String activityContent;
+        private String detailContent;
+
         public static Detail from(Announcement announcement) {
+
+            // 활동내용과 상세내용을 조합하여 하나의 본문 생성
+            String combinedContent = String.format("%s\n\n%s",
+                    announcement.getActivityContent() != null ? announcement.getActivityContent() : "",
+                    announcement.getDetailContent() != null ? announcement.getDetailContent() : ""
+            ).trim();
+
             return Detail.builder()
                     .id(announcement.getId())
                     .title(announcement.getTitle())
-                    .content(announcement.getContent())
+                    .content(combinedContent)
                     .organizer(announcement.getOrganizer())
+                    .organizerImgUrl(announcement.getOrganizerImgUrl())
                     .type(announcement.getType())
                     .imgUrl(announcement.getImgUrl())
+                    .target(announcement.getTarget())
+                    .recruitmentCount(announcement.getRecruitmentCount())
+                    .activityMethod(announcement.getActivityMethod())
+                    .applyMethod(announcement.getApplyMethod())
+                    .benefits(announcement.getBenefits())
                     .region(announcement.getRegion())
                     .location(announcement.getLocation())
                     .startDate(announcement.getStartDate())
@@ -63,68 +86,98 @@ public class AnnouncementDTO {
                     .recruitmentEnd(announcement.getRecruitmentEnd())
                     .fee(announcement.getFee())
                     .viewCount(announcement.getViewCount())
-                    .scheduleDetail(announcement.getScheduleDetail())
                     .linkUrl(announcement.getLinkUrl())
                     .serviceHoursVerified(announcement.getServiceHoursVerified())
                     .selectionProcess(announcement.getSelectionProcess())
                     .teamSize(announcement.getTeamSize())
                     .awardScale(announcement.getAwardScale())
+                    .activityContent(announcement.getActivityContent())
+                    .detailContent(announcement.getDetailContent())
+                    .schedules(announcement.getSchedules().stream()
+                            .map(s -> ScheduleResponseDTO.builder()
+                                    .scheduleDate(s.getScheduleDate())
+                                    .content(s.getContent())
+                                    .build())
+                            .toList())
                     .build();
+
         }
-    }
-
-    @Getter
-    public static class Create{
-        @NotBlank
+    }@Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Create {
+        // 1. 공고 기본 정보
+        @NotBlank(message = "공고 제목은 필수입니다.")
         private String title;
-        @NotBlank
-        private String content;
-        @NotBlank
-        private AnnouncementType type;
 
-        @NotBlank
+        @NotBlank(message = "운영 주체명은 필수입니다.")
         private String organizer;
 
-        @NotBlank
+        private String organizerImgUrl; // 선택 (기본 이미지 제공 가능)
+
+        @NotNull(message = "공고 유형은 필수입니다.")
+        private AnnouncementType type;
+
+        @NotBlank(message = "포스터 이미지 URL은 필수입니다.")
         private String imgUrl;
 
-        @NotBlank
-        private String region;
+        @NotBlank(message = "활동 지역(구)은 필수입니다.")
+        private String region; // 예: 강남구
 
-        @NotBlank
-        private String location;
+        @NotBlank(message = "상세 활동 장소는 필수입니다.")
+        private String location; // 예: 서울시 강남구...
 
+        @NotBlank(message = "활동 방식은 필수입니다.")
+        private String activityMethod; // 온라인, 오프라인
 
-        @JsonFormat(pattern = "yyyy-MM-dd")
-        private LocalDate startDate;
-
-        @JsonFormat(pattern = "yyyy-MM-dd")
-        private LocalDate endDate;
-
+        @NotNull(message = "접수 시작일은 필수입니다.")
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDate recruitmentStart;
 
+        @NotNull(message = "접수 마감일은 필수입니다.")
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDate recruitmentEnd;
 
-        private Integer fee;
+        @NotNull(message = "활동 시작일은 필수입니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate startDate;
 
-        //유형별 (선택)
+        @NotNull(message = "활동 종료일은 필수입니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        private LocalDate endDate;
 
-        // VOLUNTEER
-        private String serviceHoursVerified;
+        private String target;           // 공고 대상
+        private String recruitmentCount; // 모집 인원
+        private String applyMethod;      // 접수 방법 (홈페이지 지원 등)
+        private String linkUrl;          // 신청 링크
+        private Integer fee;             // 참가비 (null일 경우 무료 처리)
+        private String benefits;         // 활동 혜택
 
-        // SUPPORTER
-        private String selectionProcess;
+        @NotBlank(message = "활동 내용은 필수입니다.")
+        private String activityContent;
 
-        // CHALLENGE
-        private String teamSize;
-        private String awardScale;
+        @NotBlank(message = "상세 내용은 필수입니다.")
+        private String detailContent;
 
-        // 기타
+        //  유형별 추가 정보
+        private String serviceHoursVerified; // 봉사시간 인정 여부
+        private String selectionProcess;    // 심사 방식
+        private String teamSize;            // 팀원 규모
+        private String awardScale;          //  시상 규모
 
-        private String scheduleDetail;
+        // 7. 세부 일정 리스트 (V10 테이블 분리 반영)
+        private List<ScheduleRequestDTO> schedules;
 
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ScheduleRequestDTO {
+            @NotBlank
+            private String scheduleDate; // 예: "01.11"
+            @NotBlank
+            private String content;      // 예: "대면 발대식"
+        }
     }
 
     @Getter

--- a/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementSearchConditionDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementSearchConditionDTO.java
@@ -18,6 +18,7 @@ public class AnnouncementSearchConditionDTO {
     private AnnouncementType type;
     private List<String> hashtags;
     private String region;
+    private String activityMethod;
     private boolean onlyRecruiting;
 
     // 기간

--- a/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementSummaryDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/announcement/AnnouncementSummaryDTO.java
@@ -14,9 +14,11 @@ public class AnnouncementSummaryDTO {
     private Long id;
     private String title;
     private String region;
+    private String activityMethod;
     private AnnouncementType type;
     private LocalDate startDate;
     private LocalDate endDate;
+    private LocalDate recruitmentEnd;
     private String thumbnailUrl;
 
     public static AnnouncementSummaryDTO from(Announcement announcement) {
@@ -24,9 +26,11 @@ public class AnnouncementSummaryDTO {
                 .id(announcement.getId())
                 .title(announcement.getTitle())
                 .region(announcement.getRegion())
+                .activityMethod(announcement.getActivityMethod())
                 .type(announcement.getType())
                 .startDate(announcement.getStartDate())
                 .endDate(announcement.getEndDate())
+                .recruitmentEnd(announcement.getRecruitmentEnd())
                 .build();
     }
 
@@ -35,9 +39,11 @@ public class AnnouncementSummaryDTO {
                 .id(doc.getId())
                 .title(doc.getTitle())
                 .region(doc.getRegion())
+                .activityMethod(doc.getActivityMethod())
                 .type(AnnouncementType.valueOf(doc.getType()))
                 .startDate(doc.getStartDate())
                 .endDate(doc.getEndDate())
+                .recruitmentEnd(doc.getRecruitmentEnd())
                 .thumbnailUrl(doc.getThumbnailUrl())
                 .build();
     }

--- a/src/main/java/com/beanspot/backend/dto/announcement/ScheduleResponseDTO.java
+++ b/src/main/java/com/beanspot/backend/dto/announcement/ScheduleResponseDTO.java
@@ -1,0 +1,12 @@
+package com.beanspot.backend.dto.announcement;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ScheduleResponseDTO {
+    private int seqNo;
+    private String scheduleDate;
+    private String content;
+}

--- a/src/main/java/com/beanspot/backend/entity/SocialType.java
+++ b/src/main/java/com/beanspot/backend/entity/SocialType.java
@@ -1,5 +1,8 @@
 package com.beanspot.backend.entity;
 
+import com.beanspot.backend.common.exception.CustomException;
+import com.beanspot.backend.common.exception.ErrorCode;
+
 public enum SocialType {
     KAKAO,
     NAVER,
@@ -10,7 +13,7 @@ public enum SocialType {
         try{
             return SocialType.valueOf(input.toUpperCase());
         }catch (IllegalArgumentException e){
-            throw new IllegalArgumentException("Invalid social type: " + input);
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
 }

--- a/src/main/java/com/beanspot/backend/entity/User.java
+++ b/src/main/java/com/beanspot/backend/entity/User.java
@@ -15,7 +15,7 @@ public class User extends BaseEntity { // BaseEntity 상속으로 생성/수정 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false, unique = true)
     private String userId; // 사용자 로그인 아이디
 
     @Column(name = "password", length = 100)
@@ -27,7 +27,7 @@ public class User extends BaseEntity { // BaseEntity 상속으로 생성/수정 
     private String nickname; // 서비스 활동 닉네임
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "social_type")
+    @Column(name = "social_type", nullable = false)
     private SocialType socialType; // KAKAO, NAVER 등
 
     @Column(name = "social_id", unique = true)
@@ -45,7 +45,9 @@ public class User extends BaseEntity { // BaseEntity 상속으로 생성/수정 
     @Column(name = "refresh_token")
     private String refreshToken; // JWT 갱신용 토큰
 
-    private boolean emailVerified; // 이메일 인증 여부
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean emailVerified = false; // 이메일 인증 여부
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/beanspot/backend/entity/announcement/Announcement.java
+++ b/src/main/java/com/beanspot/backend/entity/announcement/Announcement.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,21 +19,27 @@ public class Announcement extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 공고 유형
     @Enumerated(EnumType.STRING)
     private AnnouncementType type;  //공고 유형
 
     private String title;           //공고 제목
 
-    @Column(columnDefinition = "TEXT")
-    private String content;         //상세 내용
+    @Column(name = "img_url")
+    private String imgUrl;      //공고 포스터
 
     private String organizer;       //운영 주체
 
-    private Integer fee;            //참가비 or 비용
+    @Column(name = "organizer_img_url")
+    private String organizerImgUrl; // 운영 주체 사진
 
-    @Column(name = "img_url")
-    private String imgUrl;      //공고 포스터
+    @Column(name = "activity_content", columnDefinition = "TEXT")
+    private String activityContent;  // 활동 내용
+
+    private String target;           // 공고 대상
+
+    private String recruitmentCount; // 모집 인원
+
+    private String applyMethod;      // 접수 방법 (온라인 접수/ 이메일 접수)
 
     @Column(name = "link_url")
     private String linkUrl;     //신청 링크
@@ -39,23 +47,47 @@ public class Announcement extends BaseEntity {
     @Column(nullable = false)
     private String location;        //활동 장소
 
-    @Column(length = 20, nullable = false)
-    private String region;          //행정구
-
     @Column(name = "start_date")
     private LocalDate startDate;    //활동 시작일
 
     @Column(name = "end_date")
     private LocalDate endDate;      //활동 종료일
 
-    @Column(columnDefinition = "TEXT") // 추후 확장시 별도 테이블로 분리
-    private String scheduleDetail;      //세부 일정
+    private String activityMethod;   // 활동 방식 (온/오프라인)
+
+
+    @OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sequenceOrder ASC")
+    private List<AnnouncementSchedule> schedules = new ArrayList<>();
 
     @Column(name = "recruitment_start")
-    private LocalDate recruitmentStart;    //모집 시작일
+    private LocalDate recruitmentStart;    //접수 시작일
 
     @Column(name = "recruitment_end")
-    private LocalDate recruitmentEnd;       //모집 마감일
+    private LocalDate recruitmentEnd;       //접수 마감일
+
+    private Integer fee;            //참가비 or 비용
+
+    @Column(name = "detail_content", columnDefinition = "TEXT")
+    private String detailContent; // 상세 내용
+
+    private String benefits;         // 활동 혜택
+
+    // volunteer
+    @Column(name = "service_hours_verified")
+    private String serviceHoursVerified;       //봉사시간 인정 여부 -> null이면 미인정
+
+    //Supporter
+
+    @Column(name = "selection_process",columnDefinition = "TEXT")
+    private String selectionProcess;        //심사 방식
+
+    @Column(name = "award_scale", columnDefinition = "TEXT")
+    private String awardScale;      //시상 규모
+
+    @Column(name = "team_size")
+    private String teamSize;        //팀원 규모
+
 
     @Column(name = "view_count")
     private int viewCount;      //조회수
@@ -64,17 +96,7 @@ public class Announcement extends BaseEntity {
     private Double lat;
     private Double lng;
 
-    // volunteer
-    @Column(name = "service_hours_verified")
-    private String serviceHoursVerified;       //봉사시간 인정 여부 -> null이면 미인정
-    //Supporter
-
-    @Column(name = "selection_process",columnDefinition = "TEXT")
-    private String selectionProcess;        //심사 방식
-    @Column(name = "award_scale", columnDefinition = "TEXT")
-    private String awardScale;      //시상 규모
-
-    @Column(name = "team_size")
-    private String teamSize;        //팀원 규모
+    @Column(length = 20, nullable = false)
+    private String region;          //행정구
 
 }

--- a/src/main/java/com/beanspot/backend/entity/announcement/Announcement.java
+++ b/src/main/java/com/beanspot/backend/entity/announcement/Announcement.java
@@ -20,13 +20,16 @@ public class Announcement extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private AnnouncementType type;  //공고 유형
 
+    @Column(nullable = false)
     private String title;           //공고 제목
 
     @Column(name = "img_url")
     private String imgUrl;      //공고 포스터
 
+    @Column(nullable = false)
     private String organizer;       //운영 주체
 
     @Column(name = "organizer_img_url")
@@ -39,6 +42,7 @@ public class Announcement extends BaseEntity {
 
     private String recruitmentCount; // 모집 인원
 
+    @Column(nullable = false)
     private String applyMethod;      // 접수 방법 (온라인 접수/ 이메일 접수)
 
     @Column(name = "link_url")
@@ -47,12 +51,13 @@ public class Announcement extends BaseEntity {
     @Column(nullable = false)
     private String location;        //활동 장소
 
-    @Column(name = "start_date")
+    @Column(name = "start_date", nullable = false)
     private LocalDate startDate;    //활동 시작일
 
-    @Column(name = "end_date")
+    @Column(name = "end_date", nullable = false)
     private LocalDate endDate;      //활동 종료일
 
+    @Column(nullable = false)
     private String activityMethod;   // 활동 방식 (온/오프라인)
 
 
@@ -60,10 +65,10 @@ public class Announcement extends BaseEntity {
     @OrderBy("sequenceOrder ASC")
     private List<AnnouncementSchedule> schedules = new ArrayList<>();
 
-    @Column(name = "recruitment_start")
+    @Column(name = "recruitment_start", nullable = false)
     private LocalDate recruitmentStart;    //접수 시작일
 
-    @Column(name = "recruitment_end")
+    @Column(name = "recruitment_end", nullable = false)
     private LocalDate recruitmentEnd;       //접수 마감일
 
     private Integer fee;            //참가비 or 비용
@@ -88,9 +93,9 @@ public class Announcement extends BaseEntity {
     @Column(name = "team_size")
     private String teamSize;        //팀원 규모
 
-
-    @Column(name = "view_count")
-    private int viewCount;      //조회수
+    @Builder.Default
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0;      //조회수
 
     //지도용 위경도
     private Double lat;

--- a/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementDocument.java
+++ b/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementDocument.java
@@ -25,17 +25,15 @@ public class AnnouncementDocument {
     @Field(type = FieldType.Text)
     private String title;
 
-    //추후 트래픽 많아지면 제거
-    @Field(type = FieldType.Text)
-    private String content;
-
     //필터
-
     @Field(type = FieldType.Keyword)
     private String type;
 
     @Field(type = FieldType.Keyword)
     private String region;
+
+    @Field(type = FieldType.Keyword)
+    private String activityMethod;
 
     // 모집/활동 기간
 
@@ -52,13 +50,13 @@ public class AnnouncementDocument {
     @Field(type = FieldType.Date)
     private LocalDate endDate;
 
-    //지도
+    //지도 (Geo-Distance 쿼리용)
     @GeoPointField
     private GeoPoint geoLocation;
 
     // 리스트 표시용
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Keyword, index = false)
     private String thumbnailUrl;
 
     //정렬
@@ -83,9 +81,9 @@ public class AnnouncementDocument {
         return  AnnouncementDocument.builder()
                 .id(announcement.getId())
                 .title(announcement.getTitle())
-                .content(announcement.getContent())
                 .type(announcement.getType().name())
                 .region(announcement.getRegion())
+                .activityMethod(announcement.getActivityMethod())
                 .recruitmentStart(announcement.getRecruitmentStart())
                 .recruitmentEnd(announcement.getRecruitmentEnd())
                 .startDate(announcement.getStartDate())

--- a/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementSchedule.java
+++ b/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementSchedule.java
@@ -1,0 +1,30 @@
+package com.beanspot.backend.entity.announcement;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "announcement_schedule")
+public class AnnouncementSchedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announcement_id")
+    private Announcement announcement;
+
+    @Column(name = "schedule_date")
+    private String scheduleDate; // 예: "01.11", "01.12" 등 날짜
+
+    @Column(nullable = false)
+    private String content;      // 예: "대면 발대식", "기자단 활동 진행"
+
+    @Column(name = "sequence_order")
+    private int sequenceOrder;
+}

--- a/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementSchedule.java
+++ b/src/main/java/com/beanspot/backend/entity/announcement/AnnouncementSchedule.java
@@ -16,15 +16,15 @@ public class AnnouncementSchedule {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "announcement_id")
+    @JoinColumn(name = "announcement_id", nullable = false)
     private Announcement announcement;
 
-    @Column(name = "schedule_date")
+    @Column(name = "schedule_date", nullable = false)
     private String scheduleDate; // 예: "01.11", "01.12" 등 날짜
 
     @Column(nullable = false)
     private String content;      // 예: "대면 발대식", "기자단 활동 진행"
 
-    @Column(name = "sequence_order")
+    @Column(name = "sequence_order", nullable = false)
     private int sequenceOrder;
 }

--- a/src/main/java/com/beanspot/backend/entity/search/SearchHistory.java
+++ b/src/main/java/com/beanspot/backend/entity/search/SearchHistory.java
@@ -1,11 +1,11 @@
 package com.beanspot.backend.entity.search;
 
+import com.beanspot.backend.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "search_history",
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
         indexes = {@Index(name = "idx_user_updated", columnList = "user_id, updated_at")})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SearchHistory {
+public class SearchHistory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,23 +24,11 @@ public class SearchHistory {
     @Column(nullable = false, length = 100)
     private String keyword;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
-
     public static SearchHistory create(Long userId, String keyword) {
-        LocalDateTime now = LocalDateTime.now();
         SearchHistory h = new SearchHistory();
         h.userId = userId;
         h.keyword = keyword;
-        h.createdAt = now;
-        h.updatedAt = now;
         return h;
     }
 
-    public void touch() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/beanspot/backend/entity/search/SortType.java
+++ b/src/main/java/com/beanspot/backend/entity/search/SortType.java
@@ -1,7 +1,8 @@
 package com.beanspot.backend.entity.search;
 
 public enum SortType {
-    POPULAR,
-    LATEST,
-    DISTANCE
+    POPULAR,   // 인기순
+    LATEST,    // 최신순
+    DISTANCE,  // 거리순
+    RECOMMENDED // 추천순
 }

--- a/src/main/java/com/beanspot/backend/repository/announcement/AnnouncementRdbSearchRepositoryImpl.java
+++ b/src/main/java/com/beanspot/backend/repository/announcement/AnnouncementRdbSearchRepositoryImpl.java
@@ -83,8 +83,7 @@ public class AnnouncementRdbSearchRepositoryImpl implements AnnouncementRdbSearc
 
     private BooleanExpression containsKeyword(String keyword) {
         if(keyword == null || keyword.isEmpty()) return null;
-        return a.title.containsIgnoreCase(keyword)
-                .or(a.content.containsIgnoreCase(keyword));
+        return a.title.containsIgnoreCase(keyword);
     }
 
     private BooleanExpression eqType(AnnouncementType type) {

--- a/src/main/java/com/beanspot/backend/repository/announcement/AnnouncementScheduleRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/announcement/AnnouncementScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.beanspot.backend.repository.announcement;
+
+import com.beanspot.backend.entity.announcement.AnnouncementSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementScheduleRepository extends JpaRepository<AnnouncementSchedule, Long> {
+}

--- a/src/main/java/com/beanspot/backend/repository/es/AnnouncementSearchRepositoryCustom.java
+++ b/src/main/java/com/beanspot/backend/repository/es/AnnouncementSearchRepositoryCustom.java
@@ -14,6 +14,7 @@ public interface AnnouncementSearchRepositoryCustom {
             String keyword,
             AnnouncementType type,
             String region,
+            String activityMethod,
             YearMonth recruitmentMonth,
             YearMonth activityMonth,
             Double minLat,

--- a/src/main/java/com/beanspot/backend/repository/es/AnnouncementSearchRepositoryImpl.java
+++ b/src/main/java/com/beanspot/backend/repository/es/AnnouncementSearchRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.beanspot.backend.repository.es;
 
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.TopLeftBottomRightGeoBounds;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.GeoBoundingBoxQuery;
@@ -32,6 +33,7 @@ public class AnnouncementSearchRepositoryImpl implements AnnouncementSearchRepos
             String keyword,
             AnnouncementType type,
             String region,
+            String activityMethod,
             YearMonth recruitmentMonth,
             YearMonth activityMonth,
             Double minLat,
@@ -48,9 +50,15 @@ public class AnnouncementSearchRepositoryImpl implements AnnouncementSearchRepos
         if(keyword != null && !keyword.isBlank()) {
             bool.must(m -> m.multiMatch(mm -> mm
                     .query(keyword)
-                    .fields("title", "content")
+                    .fields("title")
             ));
         }
+
+        // 활동 방식 필터
+        if(activityMethod != null && !activityMethod.isBlank()) {
+            bool.filter(f -> f.term(t -> t.field("activityMethod").value(activityMethod)));
+        }
+
         // 공고 유형 필터
         if(type != null ) {
             bool.filter(f -> f.term(t -> t.field("type").value(type.name())));
@@ -141,14 +149,28 @@ public class AnnouncementSearchRepositoryImpl implements AnnouncementSearchRepos
                 .withPageable(pageable);
 
         if(sort == SortType.DISTANCE && minLat != null && minLng != null){
+            //거리순 정렬
+            double centerLat = (minLat + maxLat) / 2;
+            double centerLng = (minLng + maxLng) / 2;
+
             builder.withSort(s -> s.geoDistance(g -> g
                             .field("geoLocation")
                             .location(l -> l.latlon(ll -> ll
-                                    .lat(minLat)
-                                    .lon(minLng)
+                                    .lat(centerLat)
+                                    .lon(centerLng)
                             ))
                             .order(co.elastic.clients.elasticsearch._types.SortOrder.Asc)
                     ));
+        } else if (sort == SortType.POPULAR) {
+            //조회수순 정렬
+            builder.withSort(s -> s.field(f -> f.field("viewCount").order(SortOrder.Desc)));
+        }else if (sort == SortType.RECOMMENDED) {
+            // 추천순: 마감 임박순 + 최신순
+            builder.withSort(s -> s.field(f -> f.field("endDate").order(SortOrder.Asc)));
+            builder.withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)));
+        }else {
+            // 기본 최신순
+            builder.withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)));
         }
 
         NativeQuery query = builder.build();
@@ -187,4 +209,5 @@ public class AnnouncementSearchRepositoryImpl implements AnnouncementSearchRepos
                 .distinct()
                 .toList();
     }
+
 }

--- a/src/main/java/com/beanspot/backend/service/KakaoGeoCodingService.java
+++ b/src/main/java/com/beanspot/backend/service/KakaoGeoCodingService.java
@@ -3,6 +3,7 @@ package com.beanspot.backend.service;
 import com.beanspot.backend.dto.kakaomap.KakaoAddressDTO;
 import com.beanspot.backend.dto.kakaomap.KakaoAddressResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.http.HttpEntity;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoGeoCodingService {
@@ -22,27 +24,44 @@ public class KakaoGeoCodingService {
     private String apiKey;
 
     public GeoPoint convert(String address) {
+        // 주소 데이터가 비어있는 경우 사전 방어
+        if (address == null || address.isBlank()) {
+            return null;
+//            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         String url = UriComponentsBuilder
                 .fromHttpUrl("https://dapi.kakao.com/v2/local/search/address.json")
                 .queryParam("query", address)
                 .build()
                 .toUriString();
+
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "KakaoAK " + apiKey);
 
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<KakaoAddressResponse> response =
-                restTemplate.exchange(url, HttpMethod.GET, entity, KakaoAddressResponse.class);
+        try {
+            ResponseEntity<KakaoAddressResponse> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, KakaoAddressResponse.class);
 
-        if (response.getBody() == null || response.getBody().getDocuments().isEmpty()) {
-            throw new IllegalArgumentException("주소를 좌표로 변환할 수 없습니다: " + address);
+            // API는 성공했으나 검색 결과가 없는 경우
+            if (response.getBody() == null || response.getBody().getDocuments().isEmpty()) {
+                log.info("[KakaoGeoCoding] 검색 결과 없음: {}", address);
+                return null;
+                //                throw new CustomException(ErrorCode.INVALID_LOCATION_FORMAT);
+            }
+
+            KakaoAddressDTO doc = response.getBody().getDocuments().get(0);
+
+            return new GeoPoint(
+                    Double.parseDouble(doc.getY()),
+                    Double.parseDouble(doc.getX())
+            );
+
+        } catch (Exception e) {
+            log.error("[KakaoGeoCoding] 주소 변환 중 오류 발생: {}", e.getMessage());
+            return null;
         }
-        KakaoAddressDTO doc = response.getBody().getDocuments().get(0);
-
-        return new GeoPoint(
-                Double.parseDouble(doc.getY()),
-                Double.parseDouble(doc.getX())
-        );
     }
 }

--- a/src/main/java/com/beanspot/backend/service/announcement/AnnouncementSearchService.java
+++ b/src/main/java/com/beanspot/backend/service/announcement/AnnouncementSearchService.java
@@ -5,6 +5,7 @@ import com.beanspot.backend.dto.announcement.AnnouncementSearchConditionDTO;
 import com.beanspot.backend.dto.announcement.AnnouncementSummaryDTO;
 import com.beanspot.backend.entity.announcement.AnnouncementDocument;
 import com.beanspot.backend.entity.announcement.Announcement;
+import com.beanspot.backend.entity.search.SortType;
 import com.beanspot.backend.repository.announcement.AnnouncementRdbSearchRepository;
 import com.beanspot.backend.repository.es.AnnouncementSearchRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class AnnouncementSearchService {
             AnnouncementSearchConditionDTO condition
     ){
         log.info("[AnnouncementSearch] search start - condition={}", condition);
-        // 홈 화면 (limit)
+        // 홈 화면 (limit) (RDB)
         if (condition.getLimit() != null) {
             log.info("[AnnouncementSearch][RDB] limit search 시작 (limit={})", condition.getLimit());
 
@@ -54,7 +55,7 @@ public class AnnouncementSearchService {
         Pageable pageable = PageRequest.of(
                 condition.getPage(),
                 condition.getSize(),
-                resolveSort(condition.getSort().name())
+                resolveSort(condition.getSort())
         );
         // ES 검색
         try{
@@ -66,6 +67,7 @@ public class AnnouncementSearchService {
                             condition.getKeyword(),
                             condition.getType(),
                             condition.getRegion(),
+                            condition.getActivityMethod(),
                             condition.getRecruitmentMonth(),
                             condition.getActivityMonth(),
                             condition.getMinLat(),
@@ -112,14 +114,13 @@ public class AnnouncementSearchService {
         return PageResponse.of(pageResult, dtos);
     }
 
-    private Sort resolveSort(String sort) {
-        if("popular".equals(sort)) {
-            return Sort.by(Sort.Direction.DESC,"viewCount");
-        }
-        if("endDate".equals(sort)) {
-            return Sort.by(Sort.Direction.ASC,"endDate");
-        }
-        return Sort.by(Sort.Direction.DESC, "createdAt");
+    private Sort resolveSort(SortType sortType) {
+
+        return switch (sortType) {
+            case POPULAR -> Sort.by(Sort.Direction.DESC, "viewCount");
+            case LATEST -> Sort.by(Sort.Direction.DESC, "createdAt");
+            default -> Sort.unsorted(); // Repository에서 직접 처리
+        };
     }
 
 }

--- a/src/main/java/com/beanspot/backend/service/announcement/AnnouncementServiceImpl.java
+++ b/src/main/java/com/beanspot/backend/service/announcement/AnnouncementServiceImpl.java
@@ -1,16 +1,22 @@
 package com.beanspot.backend.service.announcement;
 
+import com.beanspot.backend.common.exception.CustomException;
+import com.beanspot.backend.common.exception.ErrorCode;
 import com.beanspot.backend.common.response.PageResponse;
 import com.beanspot.backend.dto.announcement.*;
 import com.beanspot.backend.entity.announcement.*;
 import com.beanspot.backend.listener.AnnouncementCreatedEvent;
 import com.beanspot.backend.repository.announcement.AnnouncementRepository;
+import com.beanspot.backend.repository.announcement.AnnouncementScheduleRepository;
 import com.beanspot.backend.service.KakaoGeoCodingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +26,8 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     private final KakaoGeoCodingService geoCodingService;
 
     private final AnnouncementRepository announcementRepository;
-   private final ApplicationEventPublisher applicationEventPublisher;
+    private final AnnouncementScheduleRepository scheduleRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -34,7 +41,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     @Transactional(readOnly = true)
     public AnnouncementDTO.Detail getAnnouncementDetail(Long id) {
         Announcement announcement = announcementRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("No announcement found with id: " + id));
+                .orElseThrow(() -> new CustomException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
 
         return  AnnouncementDTO.Detail.from(announcement);
 
@@ -44,7 +51,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     @Transactional
     public void increaseViewCount(Long id) {
         Announcement announcement = announcementRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("No announcement found with id: " + id));
+                .orElseThrow(() -> new CustomException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
 
         announcement.setViewCount(announcement.getViewCount() + 1);
     }
@@ -52,27 +59,18 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     @Override
     @Transactional
     public void addAnnouncement(AnnouncementDTO.Create reqDTO) {
-
-        validateType(reqDTO);
-
-
-        Double lat = null;
-        Double lng = null;
-
-        try {
-            GeoPoint geo = geoCodingService.convert(reqDTO.getLocation());
-            lat = geo.getLat();
-            lng = geo.getLon();
-        } catch (Exception e) {
-            throw new IllegalArgumentException("위치 정보를 찾을 수 없습니다.");
-        }
+        GeoPoint geo = geoCodingService.convert(reqDTO.getLocation());
+        Double lat = (geo != null) ? geo.getLat() : null;
+        Double lng = (geo != null) ? geo.getLon() : null;
 
         // 공고 저장
         Announcement announcement = Announcement.builder()
                 .title(reqDTO.getTitle())
-                .content(reqDTO.getContent())
                 .type(reqDTO.getType())
+                .activityContent(reqDTO.getActivityContent())
+                .detailContent(reqDTO.getDetailContent())
                 .organizer(reqDTO.getOrganizer())
+                .organizerImgUrl(reqDTO.getOrganizerImgUrl())
                 .imgUrl(reqDTO.getImgUrl())
                 .region(reqDTO.getRegion())
                 .location(reqDTO.getLocation())
@@ -81,15 +79,33 @@ public class AnnouncementServiceImpl implements AnnouncementService {
                 .recruitmentStart(reqDTO.getRecruitmentStart())
                 .recruitmentEnd(reqDTO.getRecruitmentEnd())
                 .fee(reqDTO.getFee())
-                .scheduleDetail(reqDTO.getScheduleDetail())
                 .lat(lat)
                 .lng(lng)
                 .serviceHoursVerified(reqDTO.getServiceHoursVerified())
                 .selectionProcess(reqDTO.getSelectionProcess())
                 .awardScale(reqDTO.getAwardScale())
+                .activityMethod(reqDTO.getActivityMethod())
+                .applyMethod(reqDTO.getApplyMethod())
+                .benefits(reqDTO.getBenefits())
                 .build();
 
-        announcementRepository.save(announcement);
+        Announcement savedAnnouncement = announcementRepository.save(announcement);
+
+        if (reqDTO.getSchedules() != null) {
+            List<AnnouncementDTO.Create.ScheduleRequestDTO> scheduleDtos = reqDTO.getSchedules();
+            List<AnnouncementSchedule> schedules = IntStream.range(0, scheduleDtos.size())
+                    .mapToObj(i -> {
+                        AnnouncementDTO.Create.ScheduleRequestDTO sDto = scheduleDtos.get(i);
+                        return AnnouncementSchedule.builder()
+                                .announcement(savedAnnouncement)
+                                .scheduleDate(sDto.getScheduleDate())
+                                .content(sDto.getContent())
+                                .sequenceOrder(i + 1) // 리스트의 순서(index)를 그대로 순번으로 사용
+                                .build();
+                    })
+                    .toList();
+            scheduleRepository.saveAll(schedules);
+        }
 
         applicationEventPublisher.publishEvent(
                 new AnnouncementCreatedEvent(announcement.getId())
@@ -100,7 +116,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     @Transactional
     public void updateAnnouncement(Long id, AnnouncementDTO.Update reqDTO) {
         Announcement announcement = announcementRepository.findById(id)
-                .orElseThrow(()-> new IllegalArgumentException("공고가 존재하지 않습니다."));
+                .orElseThrow(()-> new CustomException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
 
         announcement.setTitle(reqDTO.getTitle());
         announcement.setStartDate(reqDTO.getStartDate());
@@ -111,34 +127,9 @@ public class AnnouncementServiceImpl implements AnnouncementService {
     @Transactional
     public void deleteAnnouncement(Long id) {
         if (!announcementRepository.existsById(id)) {
-            throw new IllegalArgumentException("공고가 존재하지 않습니다.");
+            throw new CustomException(ErrorCode.ANNOUNCEMENT_NOT_FOUND);
         }
         announcementRepository.deleteById(id);
     }
 
-
-    private void validateType(AnnouncementDTO.Create reqDTO) {
-        switch (reqDTO.getType()) {
-            case VOLUNTEER -> {
-                if (reqDTO.getServiceHoursVerified() == null) {
-                    throw new IllegalArgumentException("봉사시간 인정 여부는 필수입니다.");
-                }
-            }
-            case SUPPORTER -> {
-                if (reqDTO.getSelectionProcess() == null || reqDTO.getSelectionProcess().isBlank()) {
-                    throw new IllegalArgumentException("서포터즈는 심사 방식이 필요합니다.");
-                }
-            }
-            case CHALLENGE -> {
-                if (reqDTO.getTeamSize() == null || reqDTO.getTeamSize().isBlank()) {
-                    throw new IllegalArgumentException("챌린지는 팀 규모가 필요합니다.");
-                }
-            }
-            case EDUCATION -> {
-                if (reqDTO.getFee() == null) {
-                    throw new IllegalArgumentException("교육 프로그램은 비용 정보가 필요합니다.");
-                }
-            }
-        }
-    }
 }

--- a/src/main/resources/db/migration/V10__create_announcement_schedule_table.sql
+++ b/src/main/resources/db/migration/V10__create_announcement_schedule_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE announcement_schedule (
+                                       id BIGINT NOT NULL AUTO_INCREMENT,
+                                       announcement_id BIGINT NOT NULL,
+                                       schedule_date VARCHAR(100) DEFAULT NULL,
+                                       content VARCHAR(255) NOT NULL,
+                                       sequence_order INT DEFAULT 0,
+                                       PRIMARY KEY (id),
+                                       CONSTRAINT fk_schedule_announcement FOREIGN KEY (announcement_id) REFERENCES announcement_common (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V9__update_announcement_table_fields.sql
+++ b/src/main/resources/db/migration/V9__update_announcement_table_fields.sql
@@ -1,0 +1,17 @@
+ALTER TABLE announcement_common
+    -- 누락된 컬럼 추가
+    ADD COLUMN organizer_img_url VARCHAR(500) AFTER organizer,
+    ADD COLUMN activity_content TEXT AFTER organizer_img_url,
+    ADD COLUMN target VARCHAR(255) AFTER activity_content,
+    ADD COLUMN recruitment_count VARCHAR(255) AFTER target,
+    ADD COLUMN apply_method VARCHAR(255) AFTER recruitment_count,
+    ADD COLUMN activity_method VARCHAR(255) AFTER recruitment_end,
+    ADD COLUMN detail_content TEXT AFTER fee,
+    ADD COLUMN benefits VARCHAR(255) AFTER detail_content,
+
+    -- 기존 컬럼 데이터 타입 및 제약 조건 수정
+    MODIFY COLUMN type VARCHAR(255) DEFAULT NULL; -- EnumType.STRING 대응
+
+
+-- 기존에 'content'로 잘못 생성된 컬럼이 있다면 삭제 (엔티티에는 activityContent와 detailContent로 분리됨)
+ ALTER TABLE announcement_common DROP COLUMN content;

--- a/src/main/resources/elasticsearch/announcement-mapping.json
+++ b/src/main/resources/elasticsearch/announcement-mapping.json
@@ -14,14 +14,13 @@
       }
     }
   },
-  "content": {
-    "type": "text",
-    "analyzer": "korean"
-  },
   "type": {
     "type": "keyword"
   },
   "region": {
+    "type": "keyword"
+  },
+  "activityMethod": {
     "type": "keyword"
   },
   "recruitmentStart": {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #24

## 📌 개요
기획 업데이트에 맞춰 Announcement 엔티티의 필드를 세분화하고, 공고별 세부 일정을 관리할 수 있는 기능을 추가했습니다. 또한, 지도 API 연동 시 주소 형식이 불완전하더라도 공고 등록이 가능하도록 예외 처리 로직을 개선하였습니다.

## 🔍 주요 작업 내용
**1. 데이터 모델 고도화 및 DB 스키마 업데이트**
   - **엔티티 수정:** 기존 content 필드를 ctivityContent(활동 내용)와 detailContent(상세 내용)로 분리하고,
    benefits, target, applyMethod 등 총 9개의 필드를 추가했습니다.
   -  **세부일정 테이블 분리**: 공고별 다중 일정을 관리하기 위해 AnnouncementSchedule 테이블과 엔티티를 생성하였습니다.
   - **DB 마이그레이션:** 테이블 구조 변경 및 일정 관리 테이블의 마이그레이션 파일을 생성하였습니다.

**2. 서비스 로직 수정**
   - **주소 처리:** KakaoGeoCodingService 호출 시 결과가 없더라도 예외를 던지지 않고 null을 반환하도록 수정하여, 주소가 모호한 공고도 정상 등록되도록 개선하였습니다.
   
**3. 검색 엔진 명세 동기화**
   - **인덱스 매핑 최신화:** 변경된 엔티티 구조에 맞춰 announcement-mapping.json 및 AnnouncementDocument를 업데이트했습니다.
   - **검색/필터링 쿼리 반영:** 신규 필드들이 검색 결과 및 필터링 로직에 정상적으로 반영되도록 Repository 계층을 수정했습니다.

