### PR TITLE
 ci: AWS 계정 ID 하드코딩 제거 및 Secrets 참조로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
             # 1. EC2 서버에서 ECR 로그인
-            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 258143933136.dkr.ecr.ap-northeast-2.amazonaws.com
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
             
             # 2. 프로젝트 경로 이동
             cd /home/ubuntu/beanspot


### PR DESCRIPTION
## 요약                                                                                                       
  AWS 계정 ID 하드코딩 제거 및 GitHub Secrets 참조로 변경                                                     
                                                                                                                
  ## 관련 이슈                                                                                                  
  - 없음                                                                                                        
                  
  ## 변경 사항                                                                                                  
  - [x] 기타
                                                                                                                
  ## 테스트       
  - [ ] 로컬 테스트 완료
  - 테스트 방법: develop 브랜치 push 후 GitHub Actions CI 확인                                                  
                                                                                                                
  ## 롤백/리스크                                                                                                
  - 리스크 포인트: GitHub Secrets에 `AWS_ACCOUNT_ID` 등록 필요                                                  
  - 롤백 방법: 이전 커밋으로 revert          