### PR TITLE
Feat/#30 db migration chat report

### DIFF
--- a/src/main/resources/db/migration/V11__create_chat_room_table.sql
+++ b/src/main/resources/db/migration/V11__create_chat_room_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE chat_room (
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    announcement_id   BIGINT       NOT NULL,
+    room_name         VARCHAR(255) NOT NULL,
+    last_msg_content  TEXT         DEFAULT NULL,
+    last_msg_at       DATETIME(6)  DEFAULT NULL,
+    participant_count INT          NOT NULL DEFAULT 0,
+    created_at        DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_chat_room_announcement FOREIGN KEY (announcement_id) REFERENCES announcement_common (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V12__create_chat_message_table.sql
+++ b/src/main/resources/db/migration/V12__create_chat_message_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE chat_message (
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    room_id        BIGINT       NOT NULL,
+    sender_id      BIGINT       NOT NULL,
+    parent_msg_id  BIGINT       DEFAULT NULL,
+    msg_type       ENUM('TALK', 'NOTICE', 'ENTER', 'QUIT') NOT NULL,
+    content        TEXT         NOT NULL,
+    is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    reaction_count INT          NOT NULL DEFAULT 0,
+    created_at     DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_chat_message_room   FOREIGN KEY (room_id)   REFERENCES chat_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_chat_message_sender FOREIGN KEY (sender_id) REFERENCES user (id)      ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V13__create_chat_participant_table.sql
+++ b/src/main/resources/db/migration/V13__create_chat_participant_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE chat_participant (
+    id               BIGINT      NOT NULL AUTO_INCREMENT,
+    room_id          BIGINT      NOT NULL,
+    user_id          BIGINT      NOT NULL,
+    role             VARCHAR(20) NOT NULL DEFAULT 'USER',
+    entered_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    is_notified      TINYINT(1)  NOT NULL DEFAULT 1,
+    last_read_msg_id BIGINT      DEFAULT NULL,
+    is_pinned        TINYINT(1)  NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_chat_participant_room FOREIGN KEY (room_id) REFERENCES chat_room (id) ON DELETE CASCADE,
+    CONSTRAINT fk_chat_participant_user FOREIGN KEY (user_id) REFERENCES user (id)      ON DELETE CASCADE,
+    CONSTRAINT uq_chat_participant      UNIQUE (room_id, user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V14__create_chat_message_reaction_table.sql
+++ b/src/main/resources/db/migration/V14__create_chat_message_reaction_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE chat_message_reaction (
+    id            BIGINT      NOT NULL AUTO_INCREMENT,
+    msg_id        BIGINT      NOT NULL,
+    user_id       BIGINT      NOT NULL,
+    reaction_type VARCHAR(20) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_reaction_message FOREIGN KEY (msg_id)   REFERENCES chat_message (id) ON DELETE CASCADE,
+    CONSTRAINT fk_reaction_user    FOREIGN KEY (user_id) REFERENCES user (id)          ON DELETE CASCADE,
+    CONSTRAINT uq_reaction         UNIQUE (msg_id, user_id, reaction_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V15__create_report_table.sql
+++ b/src/main/resources/db/migration/V15__create_report_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE report (
+    id               BIGINT      NOT NULL AUTO_INCREMENT,
+    reporter_id      BIGINT      NOT NULL,
+    reported_user_id BIGINT      NOT NULL,
+    message_id       BIGINT      NOT NULL,
+    report_type      ENUM(
+        'INAPPROPRIATE_LANGUAGE',
+        'SEXUAL_LANGUAGE',
+        'FINANCIAL_REQUEST',
+        'ADVERTISEMENT',
+        'SPAM',
+        'OFFENSIVE',
+        'OTHER'
+    ) NOT NULL,
+    status           ENUM('PENDING', 'COMPLETED') NOT NULL DEFAULT 'PENDING',
+    created_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_report_reporter      FOREIGN KEY (reporter_id)      REFERENCES user (id)         ON DELETE CASCADE,
+    CONSTRAINT fk_report_reported_user FOREIGN KEY (reported_user_id) REFERENCES user (id)         ON DELETE CASCADE,
+    CONSTRAINT fk_report_message       FOREIGN KEY (message_id)       REFERENCES chat_message (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
 ## 📍 요약                                
  - 채팅/신고 기능에 필요한 DB 테이블 5개 Flyway 마이그레이션 스크립트 추가
                                                                                                                        
  ## 🔗 관련 이슈                                                                                                       
  - Closes #30                                                                                                          
                                                                                                                        
  ## 📌 변경 사항                                                                                                     
  - [x] 기능

  ## ✅ 작업 내용
  - V11: `chat_room` 테이블 생성 (announcement FK, lastMsg 캐시 컬럼)
  - V12: `chat_message` 테이블 생성 (room/sender FK, msgType ENUM, 답글용 parent_msg_id)                                
  - V13: `chat_participant` 테이블 생성 (user FK, room+user UNIQUE 제약, 핀/알림/lastReadMsgId)                         
  - V14: `chat_message_reaction` 테이블 생성 (msg/user FK, msg+user+type UNIQUE 제약)                                   
  - V15: `report` 테이블 생성 (ReportType 7종 ENUM, PENDING/COMPLETED 상태)                                             
                                                                                                                        
  ## 테스트                                                                                                             
  - [x] 로컬 테스트 완료                                                                                                
  - 테스트 방법:                                                                                                        
    - `./gradlew flywayClean flywayMigrate` 실행 후 테이블 생성 확인