### PR TITLE
feat: 채팅방 목록 조회 및 입장 API 구현 (#38)

### DIFF
--- a/src/main/java/com/beanspot/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/beanspot/backend/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.beanspot.backend.common.exception;
 
 import com.beanspot.backend.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,6 +15,12 @@ public class GlobalExceptionHandler {
     public ApiResponse<?> handleCustom(CustomException e) {
         log.warn("CustomException: {}", e.getMessage());
         return ApiResponse.fail(e);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleValidation(MethodArgumentNotValidException e) {
+        log.warn("Validation failed: {}", e.getMessage());
+        return ApiResponse.fail(new CustomException(ErrorCode.INVALID_INPUT_VALUE));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/beanspot/backend/controller/ChatController.java
+++ b/src/main/java/com/beanspot/backend/controller/ChatController.java
@@ -3,8 +3,15 @@ package com.beanspot.backend.controller;
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
 import com.beanspot.backend.common.exception.ExceptionDto;
+import com.beanspot.backend.common.response.ApiResponse;
 import com.beanspot.backend.dto.chat.ChatMessageDto;
+import com.beanspot.backend.dto.chat.ChatRoomCreateRequest;
+import com.beanspot.backend.dto.chat.ChatRoomResponse;
 import com.beanspot.backend.service.chat.ChatService;
+import com.beanspot.backend.security.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -16,8 +23,10 @@ import java.security.Principal;
 import java.util.List;
 
 @Slf4j
+@Tag(name = "채팅 API", description = "채팅방 생성/입장, 목록 조회, 메시지 조회 API입니다.")
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/chat")
 public class ChatController {
 
     private final SimpMessageSendingOperations messagingTemplate;
@@ -45,13 +54,27 @@ public class ChatController {
         }
     }
 
-    @GetMapping("/api/chat/rooms/{roomId}/messages")
+    @Operation(summary = "내 채팅방 목록 조회", description = "참여 중인 채팅방 목록을 최근 메시지 순으로 반환합니다.")
+    @GetMapping("/rooms")
+    public ApiResponse<List<ChatRoomResponse>> getChatRooms(@CurrentUserId Long userId) {
+        return ApiResponse.ok(chatService.getChatRooms(userId));
+    }
+
+    @Operation(summary = "채팅방 입장", description = "공고 ID에 해당하는 채팅방에 입장합니다. 채팅방은 공고 등록 시 자동으로 생성됩니다.")
+    @PostMapping("/rooms")
+    public ApiResponse<ChatRoomResponse> joinChatRoom(
+            @Valid @RequestBody ChatRoomCreateRequest request,
+            @CurrentUserId Long userId) {
+        return ApiResponse.created(chatService.joinChatRoom(userId, request));
+    }
+
+    @Operation(summary = "채팅 메시지 목록 조회", description = "커서 기반 페이지네이션. lastMessageId 없으면 최신부터, 있으면 해당 ID 이전 메시지를 조회합니다.")
+    @GetMapping("/rooms/{roomId}/messages")
     public List<ChatMessageDto> getChatMessages(
             @PathVariable Long roomId,
             @RequestParam(required = false) Long lastMessageId,
             @RequestParam(defaultValue = "30") int size,
-            Principal principal) {
-        Long userId = Long.parseLong(principal.getName());
+            @CurrentUserId Long userId) {
         return chatService.getChatMessages(roomId, userId, lastMessageId, size);
     }
 }

--- a/src/main/java/com/beanspot/backend/dto/chat/ChatRoomCreateRequest.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ChatRoomCreateRequest.java
@@ -1,0 +1,15 @@
+package com.beanspot.backend.dto.chat;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomCreateRequest {
+
+    @NotNull(message = "공고 ID는 필수입니다.")
+    private Long announcementId;
+}

--- a/src/main/java/com/beanspot/backend/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ChatRoomResponse.java
@@ -1,0 +1,30 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomResponse {
+
+    private Long roomId;
+    private Long announcementId;
+    private String roomName;
+    private String lastMsgContent;
+    private LocalDateTime lastMsgAt;
+    private Integer participantCount;
+
+    public static ChatRoomResponse from(ChatRoom room) {
+        return ChatRoomResponse.builder()
+                .roomId(room.getId())
+                .announcementId(room.getAnnouncementId())
+                .roomName(room.getRoomName())
+                .lastMsgContent(room.getLastMsgContent())
+                .lastMsgAt(room.getLastMsgAt())
+                .participantCount(room.getParticipantCount())
+                .build();
+    }
+}

--- a/src/main/java/com/beanspot/backend/listener/ChatRoomEventListener.java
+++ b/src/main/java/com/beanspot/backend/listener/ChatRoomEventListener.java
@@ -1,0 +1,35 @@
+package com.beanspot.backend.listener;
+
+import com.beanspot.backend.entity.announcement.Announcement;
+import com.beanspot.backend.entity.chat.ChatRoom;
+import com.beanspot.backend.repository.announcement.AnnouncementRepository;
+import com.beanspot.backend.repository.chat.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatRoomEventListener {
+
+    private final AnnouncementRepository announcementRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onAnnouncementCreated(AnnouncementCreatedEvent event) {
+        Announcement announcement = announcementRepository.findById(event.announcementId())
+                .orElseThrow();
+
+        chatRoomRepository.save(ChatRoom.builder()
+                .announcementId(announcement.getId())
+                .roomName(announcement.getTitle())
+                .build());
+
+        log.info("채팅방 자동 생성 완료 - announcementId: {}, title: {}", announcement.getId(), announcement.getTitle());
+    }
+}

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatParticipantRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatParticipantRepository.java
@@ -2,10 +2,15 @@ package com.beanspot.backend.repository.chat;
 
 import com.beanspot.backend.entity.chat.ChatParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
     Optional<ChatParticipant> findByChatRoomIdAndUser_Id(Long roomId, Long userId);
 
+    @Query("SELECT cp FROM ChatParticipant cp JOIN FETCH cp.chatRoom WHERE cp.user.id = :userId ORDER BY cp.chatRoom.lastMsgAt DESC NULLS LAST")
+    List<ChatParticipant> findAllByUserIdWithRoom(@Param("userId") Long userId);
 }

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatRoomRepository.java
@@ -2,10 +2,16 @@ package com.beanspot.backend.repository.chat;
 
 import com.beanspot.backend.entity.chat.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    // 특정 공고 ID(announcement_id)와 연결된 채팅방 조회
     Optional<ChatRoom> findByAnnouncementId(Long announcementId);
 
+    @Modifying
+    @Query("UPDATE ChatRoom r SET r.participantCount = r.participantCount + 1 WHERE r.id = :roomId")
+    void incrementParticipantCount(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/beanspot/backend/service/chat/ChatService.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ChatService.java
@@ -3,7 +3,10 @@ package com.beanspot.backend.service.chat;
 import com.beanspot.backend.common.exception.CustomException;
 import com.beanspot.backend.common.exception.ErrorCode;
 import com.beanspot.backend.dto.chat.ChatMessageDto;
+import com.beanspot.backend.dto.chat.ChatRoomCreateRequest;
+import com.beanspot.backend.dto.chat.ChatRoomResponse;
 import com.beanspot.backend.entity.chat.ChatMessage;
+import com.beanspot.backend.entity.chat.ChatParticipant;
 import com.beanspot.backend.entity.chat.ChatRoom;
 import com.beanspot.backend.entity.User;
 import com.beanspot.backend.repository.chat.ChatMessageRepository;
@@ -30,7 +33,6 @@ public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
     private final UserRepository userRepository;
-
     @Transactional
     public ChatMessageDto saveMessage(ChatMessageDto messageDto, String userId) {
         if (messageDto.getContent() == null || messageDto.getContent().isBlank()) {
@@ -89,5 +91,40 @@ public class ChatService {
 
         Collections.reverse(messages);
         return messages;
+    }
+
+    public List<ChatRoomResponse> getChatRooms(Long userId) {
+        return chatParticipantRepository.findAllByUserIdWithRoom(userId).stream()
+                .map(cp -> ChatRoomResponse.from(cp.getChatRoom()))
+                .toList();
+    }
+
+    @Transactional
+    public ChatRoomResponse joinChatRoom(Long userId, ChatRoomCreateRequest request) {
+        ChatRoom room = chatRoomRepository.findByAnnouncementId(request.getAnnouncementId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return joinExistingChatRoom(user, room);
+    }
+
+    private ChatRoomResponse joinExistingChatRoom(User user, ChatRoom room) {
+        boolean isAlreadyParticipant = chatParticipantRepository
+                .findByChatRoomIdAndUser_Id(room.getId(), user.getId())
+                .isPresent();
+
+        if (!isAlreadyParticipant) {
+            chatRoomRepository.incrementParticipantCount(room.getId());
+            chatParticipantRepository.save(ChatParticipant.builder()
+                    .chatRoom(room)
+                    .user(user)
+                    .role("GUEST")
+                    .build());
+            room = chatRoomRepository.findById(room.getId()).orElse(room);
+        }
+
+        return ChatRoomResponse.from(room);
     }
 }


### PR DESCRIPTION
  ## 📍 요약                                                                                                                                
  - 공고 기반 오픈채팅방 입장/목록 조회 API 구현 및 공고 생성 시 채팅방 자동 생성                                                           
                                                                                                                                            
  ## 🔗 관련 이슈                                                                                                                           
  - Closes #38                                                                                                                              
                                                                                                                                          
  ## 📌 변경 사항                                                                                                                           
  - [x] 기능                                                                                                                                
  - [x] 버그 수정                                                                                                                           
                                                                                                                                            
  ## ✅ 작업 내용                                                                                                                           
  - `POST /api/chat/rooms` — 공고 ID 기반 채팅방 입장 (없으면 404, 이미 참여 중이면 그대로 반환)                                            
  - `GET /api/chat/rooms` — 참여 중인 채팅방 목록 조회 (최근 메시지 순)                                                                     
  - `ChatRoomEventListener` — 공고 등록 시 채팅방 자동 생성                                                                                 
  - `participantCount` 동시성 이슈 → `@Modifying` 쿼리로 처리
  - `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 핸들러 추가                                                                
  - `@CurrentUserId` 어노테이션으로 userId 추출 방식 통일                                                                                   
                                                                                                                                          
  ## 테스트                                                                                                                                 
  - [x] 로컬 테스트 완료                                                                                                                  
  - 테스트 방법:                                                                                                                            
    - Swagger `/swagger-ui/index.html`에서 토큰 2개로 입장/목록/중복입장/예외케이스 확인