### PR TITLE
fix: Report 엔티티 @Builder.Default 제거로 컴파일 오류 수정 (#39)

### DIFF
--- a/src/main/java/com/beanspot/backend/entity/Report.java
+++ b/src/main/java/com/beanspot/backend/entity/Report.java
@@ -35,8 +35,7 @@ public class Report {
     private ReportType reportType;
 
     @Enumerated(EnumType.STRING)
-    @Builder.Default
-    private ReportStatus status = ReportStatus.PENDING;
+    private ReportStatus status;
 
     private LocalDateTime createdAt;
 


### PR DESCRIPTION
  ## 📍 요약
  @Builder.Default 오용으로 인한 Lombok 컴파일 오류 수정
                                                                                                                        
  ## 🔗 관련 이슈
  #39                                                                                                                   
                                                                                                                      
  ## 📌 변경 사항                                                                                                       
  - [ ] 기능
  - [x] 버그수정                                                                                                        
  - [ ] 리팩토링                                                                                                      
  - [ ] 문서
  - [ ] 테스트
  - [ ] 기타

  ## ✅ 작업 내용                                                                                                       
  - `Report.status` 필드의 `@Builder.Default` 제거
  - 기본값은 생성자 내 `this.status = ReportStatus.PENDING`으로 처리                                                    
                                                                                                                        
  ## 테스트
  - [x] 로컬 테스트 완료                                                                                                
  - CI 빌드 통과 확인