### PR TITLE
feat: 채팅 메시지 리액션 기능 구현 (#33)

### DIFF
--- a/src/main/java/com/beanspot/backend/controller/ChatController.java
+++ b/src/main/java/com/beanspot/backend/controller/ChatController.java
@@ -8,6 +8,10 @@ import com.beanspot.backend.dto.chat.ChatMessageDto;
 import com.beanspot.backend.dto.chat.ChatParticipantResponse;
 import com.beanspot.backend.dto.chat.ChatRoomCreateRequest;
 import com.beanspot.backend.dto.chat.ChatRoomResponse;
+import com.beanspot.backend.dto.chat.ReactionBroadcastDto;
+import com.beanspot.backend.dto.chat.ReactionResultDto;
+import com.beanspot.backend.dto.chat.ReactionStompRequest;
+import com.beanspot.backend.service.chat.ReactionService;
 import com.beanspot.backend.entity.chat.ChatMessageType;
 import com.beanspot.backend.service.chat.ChatService;
 import com.beanspot.backend.security.CurrentUserId;
@@ -33,6 +37,7 @@ public class ChatController {
 
     private final SimpMessageSendingOperations messagingTemplate;
     private final ChatService chatService;
+    private final ReactionService reactionService;
 
     @MessageMapping("/chat/message")
     public void message(ChatMessageDto message, Principal principal) {
@@ -43,6 +48,22 @@ public class ChatController {
 
         ChatMessageDto response = chatService.saveMessage(message, principal.getName());
         messagingTemplate.convertAndSend("/sub/chat/room/" + response.getRoomId(), response);
+    }
+
+    @MessageMapping("/chat/reaction")
+    public void reaction(ReactionStompRequest request, Principal principal) {
+        if (principal == null) {
+            log.error("인증 정보를 찾을 수 없습니다.");
+            return;
+        }
+
+        Long userId = Long.parseLong(principal.getName());
+        ReactionResultDto result = reactionService.toggleReaction(userId, request.getMessageId(), request.getReactionType());
+
+        messagingTemplate.convertAndSend(
+                "/sub/chat/room/" + request.getRoomId(),
+                ReactionBroadcastDto.of(request.getMessageId(), result.reactionType(), result.count(), userId, result.added())
+        );
     }
 
     @MessageExceptionHandler

--- a/src/main/java/com/beanspot/backend/dto/chat/ChatMessageDto.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ChatMessageDto.java
@@ -4,6 +4,7 @@ import com.beanspot.backend.entity.chat.ChatMessageType;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -18,6 +19,7 @@ public class ChatMessageDto {
     private String content;
     private Long parentMsgId;
     private int reactionCount;
+    private List<ReactionSummaryDto> reactions;
     private LocalDateTime createdAt;
 
     public ChatMessageDto withSenderAndId(String sender, Long messageId) {
@@ -29,6 +31,7 @@ public class ChatMessageDto {
                 .content(this.content)
                 .parentMsgId(this.parentMsgId)
                 .reactionCount(this.reactionCount)
+                .reactions(List.of())
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/beanspot/backend/dto/chat/ReactionBroadcastDto.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ReactionBroadcastDto.java
@@ -1,0 +1,16 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ReactionType;
+
+public record ReactionBroadcastDto(
+        String msgType,
+        Long messageId,
+        ReactionType reactionType,
+        long count,
+        Long actorUserId,
+        boolean added
+) {
+    public static ReactionBroadcastDto of(Long messageId, ReactionType reactionType, long count, Long actorUserId, boolean added) {
+        return new ReactionBroadcastDto("REACTION", messageId, reactionType, count, actorUserId, added);
+    }
+}

--- a/src/main/java/com/beanspot/backend/dto/chat/ReactionMappingDto.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ReactionMappingDto.java
@@ -1,0 +1,9 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ReactionType;
+
+public record ReactionMappingDto(
+        Long messageId,
+        ReactionType reactionType,
+        Long userId
+) {}

--- a/src/main/java/com/beanspot/backend/dto/chat/ReactionResultDto.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ReactionResultDto.java
@@ -1,0 +1,9 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ReactionType;
+
+public record ReactionResultDto(
+        ReactionType reactionType,
+        long count,
+        boolean added
+) {}

--- a/src/main/java/com/beanspot/backend/dto/chat/ReactionStompRequest.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ReactionStompRequest.java
@@ -1,0 +1,20 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ReactionType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReactionStompRequest {
+
+    @NotNull
+    private Long roomId;
+
+    @NotNull
+    private Long messageId;
+
+    @NotNull
+    private ReactionType reactionType;
+}

--- a/src/main/java/com/beanspot/backend/dto/chat/ReactionSummaryDto.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ReactionSummaryDto.java
@@ -1,0 +1,13 @@
+package com.beanspot.backend.dto.chat;
+
+import com.beanspot.backend.entity.chat.ReactionType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReactionSummaryDto {
+    private ReactionType reactionType;
+    private long count;
+    private boolean reacted;
+}

--- a/src/main/java/com/beanspot/backend/entity/chat/ChatMessageReaction.java
+++ b/src/main/java/com/beanspot/backend/entity/chat/ChatMessageReaction.java
@@ -27,5 +27,6 @@ public class ChatMessageReaction extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private String reactionType;
+    @Enumerated(EnumType.STRING)
+    private ReactionType reactionType;
 }

--- a/src/main/java/com/beanspot/backend/entity/chat/ReactionType.java
+++ b/src/main/java/com/beanspot/backend/entity/chat/ReactionType.java
@@ -1,0 +1,9 @@
+package com.beanspot.backend.entity.chat;
+
+public enum ReactionType {
+    SMILE,
+    SURPRISE,
+    CRY,
+    NEUTRAL,
+    ANGRY
+}

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatMessageReactionRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatMessageReactionRepository.java
@@ -1,0 +1,30 @@
+package com.beanspot.backend.repository.chat;
+
+import com.beanspot.backend.entity.chat.ChatMessageReaction;
+import com.beanspot.backend.entity.chat.ReactionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.beanspot.backend.dto.chat.ReactionMappingDto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageReactionRepository extends JpaRepository<ChatMessageReaction, Long> {
+    Optional<ChatMessageReaction> findByChatMessage_IdAndUser_IdAndReactionType(Long messageId, Long userId, ReactionType reactionType);
+
+    @Query("SELECT new com.beanspot.backend.dto.chat.ReactionMappingDto(r.chatMessage.id, r.reactionType, r.user.id) " +
+           "FROM ChatMessageReaction r WHERE r.chatMessage.id IN :messageIds")
+    List<ReactionMappingDto> findReactionMappingsByMessageIds(@Param("messageIds") List<Long> messageIds);
+
+    long countByChatMessage_IdAndReactionType(Long messageId, ReactionType reactionType);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ChatMessage m SET m.reactionCount = m.reactionCount + 1 WHERE m.id = :messageId")
+    void incrementReactionCount(@Param("messageId") Long messageId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ChatMessage m SET m.reactionCount = CASE WHEN m.reactionCount > 0 THEN m.reactionCount - 1 ELSE 0 END WHERE m.id = :messageId")
+    void decrementReactionCount(@Param("messageId") Long messageId);
+}

--- a/src/main/java/com/beanspot/backend/service/chat/ChatService.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ChatService.java
@@ -6,10 +6,14 @@ import com.beanspot.backend.dto.chat.ChatMessageDto;
 import com.beanspot.backend.dto.chat.ChatParticipantResponse;
 import com.beanspot.backend.dto.chat.ChatRoomCreateRequest;
 import com.beanspot.backend.dto.chat.ChatRoomResponse;
+import com.beanspot.backend.dto.chat.ReactionMappingDto;
+import com.beanspot.backend.dto.chat.ReactionSummaryDto;
+import com.beanspot.backend.entity.chat.ReactionType;
 import com.beanspot.backend.entity.chat.ChatMessage;
 import com.beanspot.backend.entity.chat.ChatParticipant;
 import com.beanspot.backend.entity.chat.ChatRoom;
 import com.beanspot.backend.entity.User;
+import com.beanspot.backend.repository.chat.ChatMessageReactionRepository;
 import com.beanspot.backend.repository.chat.ChatMessageRepository;
 import com.beanspot.backend.repository.chat.ChatParticipantRepository;
 import com.beanspot.backend.repository.chat.ChatRoomRepository;
@@ -24,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +37,7 @@ import java.util.List;
 public class ChatService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageReactionRepository chatMessageReactionRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
     private final UserRepository userRepository;
@@ -77,17 +84,42 @@ public class ChatService {
                 ? chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, pageable)
                 : chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(roomId, lastMessageId, pageable);
 
-        List<ChatMessageDto> messages = new ArrayList<>(slice.getContent().stream()
-                .map(entity -> ChatMessageDto.builder()
-                        .messageId(entity.getId())
-                        .msgType(entity.getMsgType())
-                        .roomId(entity.getChatRoom().getId())
-                        .sender(entity.getSender().getNickname())
-                        .content(entity.getContent())
-                        .parentMsgId(entity.getParentMsgId())
-                        .reactionCount(entity.getReactionCount())
-                        .createdAt(entity.getCreatedAt())
-                        .build())
+        List<ChatMessage> content = slice.getContent();
+        List<Long> messageIds = content.stream().map(ChatMessage::getId).toList();
+
+        Map<Long, Map<ReactionType, List<ReactionMappingDto>>> reactionsByMsgAndType =
+                chatMessageReactionRepository.findReactionMappingsByMessageIds(messageIds).stream()
+                        .collect(Collectors.groupingBy(
+                                ReactionMappingDto::messageId,
+                                Collectors.groupingBy(ReactionMappingDto::reactionType)
+                        ));
+
+        List<ChatMessageDto> messages = new ArrayList<>(content.stream()
+                .map(entity -> {
+                    Map<ReactionType, List<ReactionMappingDto>> byType =
+                            reactionsByMsgAndType.getOrDefault(entity.getId(), Map.of());
+
+                    List<ReactionSummaryDto> reactions = byType.entrySet().stream()
+                            .map(e -> ReactionSummaryDto.builder()
+                                    .reactionType(e.getKey())
+                                    .count(e.getValue().size())
+                                    .reacted(e.getValue().stream()
+                                            .anyMatch(r -> r.userId().equals(userId)))
+                                    .build())
+                            .toList();
+
+                    return ChatMessageDto.builder()
+                            .messageId(entity.getId())
+                            .msgType(entity.getMsgType())
+                            .roomId(entity.getChatRoom().getId())
+                            .sender(entity.getSender().getNickname())
+                            .content(entity.getContent())
+                            .parentMsgId(entity.getParentMsgId())
+                            .reactionCount(entity.getReactionCount())
+                            .reactions(reactions)
+                            .createdAt(entity.getCreatedAt())
+                            .build();
+                })
                 .toList());
 
         Collections.reverse(messages);

--- a/src/main/java/com/beanspot/backend/service/chat/ReactionService.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ReactionService.java
@@ -1,0 +1,61 @@
+package com.beanspot.backend.service.chat;
+
+import com.beanspot.backend.common.exception.CustomException;
+import com.beanspot.backend.common.exception.ErrorCode;
+import com.beanspot.backend.dto.chat.ReactionResultDto;
+import com.beanspot.backend.entity.User;
+import com.beanspot.backend.entity.chat.ChatMessage;
+import com.beanspot.backend.entity.chat.ChatMessageReaction;
+import com.beanspot.backend.entity.chat.ReactionType;
+import com.beanspot.backend.repository.UserRepository;
+import com.beanspot.backend.repository.chat.ChatMessageReactionRepository;
+import com.beanspot.backend.repository.chat.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReactionService {
+
+    private final ChatMessageReactionRepository reactionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReactionResultDto toggleReaction(Long userId, Long messageId, ReactionType reactionType) {
+        ChatMessage message = chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (message.isDeleted()) {
+            throw new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Optional<ChatMessageReaction> existing = reactionRepository
+                .findByChatMessage_IdAndUser_IdAndReactionType(messageId, userId, reactionType);
+
+        boolean added;
+        if (existing.isPresent()) {
+            reactionRepository.delete(existing.get());
+            reactionRepository.decrementReactionCount(messageId);
+            added = false;
+        } else {
+            reactionRepository.save(ChatMessageReaction.builder()
+                    .chatMessage(message)
+                    .user(user)
+                    .reactionType(reactionType)
+                    .build());
+            reactionRepository.incrementReactionCount(messageId);
+            added = true;
+        }
+
+        long count = reactionRepository.countByChatMessage_IdAndReactionType(messageId, reactionType);
+        return new ReactionResultDto(reactionType, count, added);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,12 @@ oauth:
 springdoc:
   swagger-ui:
     path: ${SPRINGDOC_SWAGGER_UI_PATH}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/db/migration/V20__modify_reaction_type_to_enum.sql
+++ b/src/main/resources/db/migration/V20__modify_reaction_type_to_enum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_message_reaction MODIFY COLUMN reaction_type ENUM('SMILE', 'SURPRISE', 'CRY', 'NEUTRAL', 'ANGRY') NOT NULL;


### PR DESCRIPTION
  📍 요약
  채팅 메시지에 이모지 리액션을 달고 취소할 수 있는 기능을 구현합니다.

  🔗 관련 이슈
  Closes #33

  📌 변경 사항
  - [x] 기능

  ✅ 작업 내용
  - ReactionType enum 정의 (SMILE, SURPRISE, CRY, NEUTRAL, ANGRY)
  - STOMP `/pub/chat/reaction` 핸들러 구현 (토글 방식, 같은 타입 재요청 시 취소)
  - 리액션 토글 후 `/sub/chat/room/{roomId}` 로 실시간 브로드캐스트
  - 브로드캐스트 payload: messageId, reactionType, count(타입별), actorUserId, added
  - 채팅 메시지 목록 조회 시 reactions 배열 포함 (타입별 count, 본인 반응 여부)

  테스트
  - [x] 로컬 테스트 완료
  - STOMP 연결 후 리액션 토글 → 브로드캐스트 수신 확인
  - 메시지 목록 조회 시 reactions 필드 정상 응답 확인