### PR TITLE
feat: 채팅 읽음 처리 구현 (#40)

### DIFF
--- a/src/main/java/com/beanspot/backend/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/ChatRoomResponse.java
@@ -17,6 +17,7 @@ public class ChatRoomResponse {
     private String lastMsgContent;
     private LocalDateTime lastMsgAt;
     private Integer participantCount;
+    private long unreadCount;
     @JsonIgnore
     private boolean isNewParticipant;
 
@@ -28,6 +29,19 @@ public class ChatRoomResponse {
                 .lastMsgContent(room.getLastMsgContent())
                 .lastMsgAt(room.getLastMsgAt())
                 .participantCount(room.getParticipantCount())
+                .isNewParticipant(isNewParticipant)
+                .build();
+    }
+
+    public static ChatRoomResponse from(ChatRoom room, boolean isNewParticipant, long unreadCount) {
+        return ChatRoomResponse.builder()
+                .roomId(room.getId())
+                .announcementId(room.getAnnouncementId())
+                .roomName(room.getRoomName())
+                .lastMsgContent(room.getLastMsgContent())
+                .lastMsgAt(room.getLastMsgAt())
+                .participantCount(room.getParticipantCount())
+                .unreadCount(unreadCount)
                 .isNewParticipant(isNewParticipant)
                 .build();
     }

--- a/src/main/java/com/beanspot/backend/dto/chat/UnreadCountProjection.java
+++ b/src/main/java/com/beanspot/backend/dto/chat/UnreadCountProjection.java
@@ -1,0 +1,6 @@
+package com.beanspot.backend.dto.chat;
+
+public interface UnreadCountProjection {
+    Long getRoomId();
+    Long getUnreadCount();
+}

--- a/src/main/java/com/beanspot/backend/entity/chat/ChatParticipant.java
+++ b/src/main/java/com/beanspot/backend/entity/chat/ChatParticipant.java
@@ -52,4 +52,8 @@ public class ChatParticipant extends BaseEntity {
     public void toggleNotification() {
         this.isNotified = !this.isNotified;
     }
+
+    public void updateLastReadMsgId(Long messageId) {
+        this.lastReadMsgId = messageId;
+    }
 }

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package com.beanspot.backend.repository.chat;
 
+import com.beanspot.backend.dto.chat.UnreadCountProjection;
 import com.beanspot.backend.entity.chat.ChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -19,4 +21,14 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("SELECT m FROM ChatMessage m JOIN FETCH m.sender WHERE m.id = :messageId")
     Optional<ChatMessage> findByIdWithSender(@Param("messageId") Long messageId);
+
+    Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long roomId);
+
+    @Query("SELECT m.chatRoom.id AS roomId, COUNT(m.id) AS unreadCount " +
+           "FROM ChatMessage m " +
+           "JOIN ChatParticipant cp ON m.chatRoom.id = cp.chatRoom.id " +
+           "WHERE cp.user.id = :userId " +
+           "AND (cp.lastReadMsgId IS NULL OR m.id > cp.lastReadMsgId) " +
+           "GROUP BY m.chatRoom.id")
+    List<UnreadCountProjection> countUnreadMessagesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/beanspot/backend/security/WebSecurityConfig.java
+++ b/src/main/java/com/beanspot/backend/security/WebSecurityConfig.java
@@ -31,6 +31,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/",
                                 "/index.html",
+                                "/stomp-test.html",
                                 "/api/auth/**",
                                 "/actuator/health",
                                 "/swagger-ui/**",

--- a/src/main/java/com/beanspot/backend/service/chat/ChatService.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ChatService.java
@@ -8,6 +8,7 @@ import com.beanspot.backend.dto.chat.ChatRoomCreateRequest;
 import com.beanspot.backend.dto.chat.ChatRoomResponse;
 import com.beanspot.backend.dto.chat.ReactionMappingDto;
 import com.beanspot.backend.dto.chat.ReactionSummaryDto;
+import com.beanspot.backend.dto.chat.UnreadCountProjection;
 import com.beanspot.backend.entity.chat.ReactionType;
 import com.beanspot.backend.entity.chat.ChatMessage;
 import com.beanspot.backend.entity.chat.ChatParticipant;
@@ -133,9 +134,23 @@ public class ChatService {
     }
 
     public List<ChatRoomResponse> getChatRooms(Long userId) {
-        return chatParticipantRepository.findAllByUserIdWithRoom(userId).stream()
-                .map(cp -> ChatRoomResponse.from(cp.getChatRoom(), false))
+        List<ChatParticipant> participants = chatParticipantRepository.findAllByUserIdWithRoom(userId);
+
+        Map<Long, Long> unreadCountMap = chatMessageRepository.countUnreadMessagesByUserId(userId).stream()
+                .collect(Collectors.toMap(UnreadCountProjection::getRoomId, UnreadCountProjection::getUnreadCount));
+
+        return participants.stream()
+                .map(cp -> ChatRoomResponse.from(cp.getChatRoom(), false,
+                        unreadCountMap.getOrDefault(cp.getChatRoom().getId(), 0L)))
                 .toList();
+    }
+
+    @Transactional
+    public void saveLastReadMsgId(Long userId, Long roomId) {
+        chatParticipantRepository.findByChatRoomIdAndUser_Id(roomId, userId).ifPresent(participant ->
+                chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId)
+                        .ifPresent(msg -> participant.updateLastReadMsgId(msg.getId()))
+        );
     }
 
     @Transactional

--- a/src/main/java/com/beanspot/backend/service/chat/StompEventListener.java
+++ b/src/main/java/com/beanspot/backend/service/chat/StompEventListener.java
@@ -1,0 +1,87 @@
+package com.beanspot.backend.service.chat;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompEventListener {
+
+    private static final String ROOM_DEST_PREFIX = "/sub/chat/room/";
+
+    private final ChatService chatService;
+
+    // sessionId -> subscriptionId -> SubscriptionInfo(roomId, userId)
+    private final ConcurrentHashMap<String, Map<String, SubscriptionInfo>> subscriptions = new ConcurrentHashMap<>();
+
+    @EventListener
+    public void handleSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String dest = accessor.getDestination();
+        if (dest == null || !dest.startsWith(ROOM_DEST_PREFIX)) return;
+
+        String sessionId = accessor.getSessionId();
+        String subId = accessor.getSubscriptionId();
+        if (sessionId == null || subId == null || accessor.getUser() == null) return;
+
+        try {
+            Long roomId = Long.parseLong(dest.substring(ROOM_DEST_PREFIX.length()));
+            Long userId = Long.parseLong(accessor.getUser().getName());
+            SubscriptionInfo info = new SubscriptionInfo(roomId, userId);
+            subscriptions
+                    .computeIfAbsent(sessionId, k -> new ConcurrentHashMap<>())
+                    .put(subId, info);
+            saveLastRead(info);
+        } catch (NumberFormatException e) {
+            log.warn("구독 경로 파싱 실패: {}", dest);
+        }
+    }
+
+    @EventListener
+    public void handleUnsubscribe(SessionUnsubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        String subId = accessor.getSubscriptionId();
+        if (sessionId == null || subId == null) return;
+
+        Map<String, SubscriptionInfo> subs = subscriptions.get(sessionId);
+        if (subs == null) return;
+
+        SubscriptionInfo info = subs.remove(subId);
+        if (info != null) {
+            saveLastRead(info);
+        }
+    }
+
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        if (sessionId == null) return;
+
+        Map<String, SubscriptionInfo> subs = subscriptions.remove(sessionId);
+        if (subs == null) return;
+
+        subs.values().forEach(this::saveLastRead);
+    }
+
+    private void saveLastRead(SubscriptionInfo info) {
+        try {
+            chatService.saveLastReadMsgId(info.userId(), info.roomId());
+        } catch (Exception e) {
+            log.error("lastReadMsgId 저장 실패 - userId: {}, roomId: {}", info.userId(), info.roomId(), e);
+        }
+    }
+
+    private record SubscriptionInfo(Long roomId, Long userId) {}
+}


### PR DESCRIPTION
  ## 📍 요약                                                                                               
  STOMP 세션 이벤트 기반으로 lastReadMsgId를 자동 저장하고, 채팅방 목록 조회 시 unreadCount를 반환합니다.  
                                                                                                         
  ## 🔗 관련 이슈                                                                                          
  Closes #40                                                                                               
                                                                                                           
  ## 📌 변경 사항                                                                                          
  - [x] 기능                                                                                             
            
  ## ✅ 작업 내용
  - `StompEventListener` 추가: SUBSCRIBE/UNSUBSCRIBE/DISCONNECT 이벤트 감지 시 lastReadMsgId 자동 저장
  - 채팅방 입장(구독) 즉시 lastReadMsgId 저장 → 방 들어가는 순간 unread 뱃지 초기화                   
  - 앱 종료/백그라운드 전환으로 연결 끊길 때도 저장 (SessionDisconnectEvent)                               
  - 채팅방 목록 조회(`GET /api/chat/rooms`) 응답에 `unreadCount` 필드 추가                                 
  - N+1 방지: GROUP BY 단일 쿼리로 전체 채팅방 unread count 일괄 조회                                      
                                                                                                           
  ## 테스트                                                                                                
  - [x] 로컬 테스트 완료                                                                                   
  - STOMP 연결 → 구독 → 메시지 전송 → unreadCount 확인                                                     
  - 구독 해제 후 unreadCount 0 확인