### PR TITLE
feat: 채팅 메시지 7일 보관 정책 적용 (#52)

### DIFF
--- a/src/main/java/com/beanspot/backend/BackendApplication.java
+++ b/src/main/java/com/beanspot/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.beanspot.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/beanspot/backend/controller/ChatController.java
+++ b/src/main/java/com/beanspot/backend/controller/ChatController.java
@@ -141,4 +141,15 @@ public class ChatController {
             @CurrentUserId Long userId) {
         return ApiResponse.ok(chatService.getChatMessages(roomId, userId, lastMessageId, size));
     }
+
+    @Operation(summary = "7일 이전 메시지 조회 (클라이언트 동기화용)",
+               description = "서버에서 삭제 예정인 7일 이전 메시지를 조회합니다. 클라이언트 로컬 DB 동기화에 사용하세요.")
+    @GetMapping("/rooms/{roomId}/messages/archive")
+    public ApiResponse<List<ChatMessageDto>> getArchivedMessages(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long lastMessageId,
+            @RequestParam(defaultValue = "50") int size,
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(chatService.getArchivedMessages(roomId, userId, lastMessageId, size));
+    }
 }

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatMessageReactionRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatMessageReactionRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import com.beanspot.backend.dto.chat.ReactionMappingDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,4 +29,15 @@ public interface ChatMessageReactionRepository extends JpaRepository<ChatMessage
     @Modifying(clearAutomatically = true)
     @Query("UPDATE ChatMessage m SET m.reactionCount = CASE WHEN m.reactionCount > 0 THEN m.reactionCount - 1 ELSE 0 END WHERE m.id = :messageId")
     void decrementReactionCount(@Param("messageId") Long messageId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "DELETE FROM chat_message_reaction WHERE id IN " +
+                   "(SELECT id FROM (SELECT r.id FROM chat_message_reaction r " +
+                   "JOIN chat_message m ON r.msg_id = m.id " +
+                   "WHERE m.created_at < :cutoff " +
+                   "ORDER BY r.id ASC LIMIT :chunkSize) AS tmp)",
+           nativeQuery = true)
+    int deleteReactionsForExpiredMessagesChunk(@Param("cutoff") LocalDateTime cutoff,
+                                               @Param("chunkSize") int chunkSize);
 }

--- a/src/main/java/com/beanspot/backend/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/beanspot/backend/repository/chat/ChatMessageRepository.java
@@ -5,9 +5,12 @@ import com.beanspot.backend.entity.chat.ChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,6 +26,32 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     Optional<ChatMessage> findByIdWithSender(@Param("messageId") Long messageId);
 
     Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long roomId);
+
+    @Query("SELECT m FROM ChatMessage m JOIN FETCH m.sender " +
+           "WHERE m.chatRoom.id = :roomId AND m.createdAt < :cutoff " +
+           "ORDER BY m.id DESC")
+    Slice<ChatMessage> findArchiveByChatRoomId(@Param("roomId") Long roomId,
+                                               @Param("cutoff") LocalDateTime cutoff,
+                                               Pageable pageable);
+
+    @Query("SELECT m FROM ChatMessage m JOIN FETCH m.sender " +
+           "WHERE m.chatRoom.id = :roomId AND m.createdAt < :cutoff AND m.id < :lastMessageId " +
+           "ORDER BY m.id DESC")
+    Slice<ChatMessage> findArchiveByChatRoomIdAndIdLessThan(@Param("roomId") Long roomId,
+                                                            @Param("cutoff") LocalDateTime cutoff,
+                                                            @Param("lastMessageId") Long lastMessageId,
+                                                            Pageable pageable);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "DELETE FROM chat_message WHERE id IN " +
+                   "(SELECT id FROM (SELECT m.id FROM chat_message m " +
+                   "LEFT JOIN report r ON m.id = r.message_id " +
+                   "WHERE m.created_at < :cutoff AND r.id IS NULL " +
+                   "ORDER BY m.id ASC LIMIT :chunkSize) AS tmp)",
+           nativeQuery = true)
+    int deleteExpiredMessagesChunk(@Param("cutoff") LocalDateTime cutoff,
+                                   @Param("chunkSize") int chunkSize);
 
     @Query("SELECT m.chatRoom.id AS roomId, COUNT(m.id) AS unreadCount " +
            "FROM ChatMessage m " +

--- a/src/main/java/com/beanspot/backend/service/chat/ChatMessageRetentionScheduler.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ChatMessageRetentionScheduler.java
@@ -1,0 +1,40 @@
+package com.beanspot.backend.service.chat;
+
+import com.beanspot.backend.repository.chat.ChatMessageReactionRepository;
+import com.beanspot.backend.repository.chat.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageRetentionScheduler {
+
+    private static final int CHUNK_SIZE = 1000;
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageReactionRepository chatMessageReactionRepository;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void deleteExpiredMessages() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
+        int totalReactions = 0, totalMessages = 0, deleted;
+
+        do {
+            deleted = chatMessageReactionRepository.deleteReactionsForExpiredMessagesChunk(cutoff, CHUNK_SIZE);
+            totalReactions += deleted;
+        } while (deleted == CHUNK_SIZE);
+
+        do {
+            deleted = chatMessageRepository.deleteExpiredMessagesChunk(cutoff, CHUNK_SIZE);
+            totalMessages += deleted;
+        } while (deleted == CHUNK_SIZE);
+
+        log.info("[채팅 보관 정책] 7일 이전 메시지 삭제 완료 (기준: {}) - reactions: {}건, messages: {}건",
+                cutoff.toLocalDate(), totalReactions, totalMessages);
+    }
+}

--- a/src/main/java/com/beanspot/backend/service/chat/ChatService.java
+++ b/src/main/java/com/beanspot/backend/service/chat/ChatService.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -193,6 +194,38 @@ public class ChatService {
 
         chatParticipantRepository.delete(participant);
         chatRoomRepository.decrementParticipantCount(roomId);
+    }
+
+    public List<ChatMessageDto> getArchivedMessages(Long roomId, Long userId, Long lastMessageId, int size) {
+        chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        chatParticipantRepository.findByChatRoomIdAndUser_Id(roomId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_NOT_PARTICIPANT));
+
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
+        Pageable pageable = PageRequest.of(0, size);
+
+        Slice<ChatMessage> slice = (lastMessageId == null)
+                ? chatMessageRepository.findArchiveByChatRoomId(roomId, cutoff, pageable)
+                : chatMessageRepository.findArchiveByChatRoomIdAndIdLessThan(roomId, cutoff, lastMessageId, pageable);
+
+        List<ChatMessageDto> messages = new ArrayList<>(slice.getContent().stream()
+                .map(entity -> ChatMessageDto.builder()
+                        .messageId(entity.getId())
+                        .msgType(entity.getMsgType())
+                        .roomId(entity.getChatRoom().getId())
+                        .sender(entity.getSender().getNickname())
+                        .content(entity.getContent())
+                        .parentMsgId(entity.getParentMsgId())
+                        .reactionCount(entity.getReactionCount())
+                        .reactions(List.of())
+                        .createdAt(entity.getCreatedAt())
+                        .build())
+                .toList());
+
+        Collections.reverse(messages);
+        return messages;
     }
 
     private ChatRoomResponse joinExistingChatRoom(User user, ChatRoom room) {


### PR DESCRIPTION
  ## 📍 요약
  서버 DB 부하 감소를 위해 채팅 메시지를 7일간만 보관하고,
  이전 메시지는 클라이언트 로컬 DB에서 조회할 수 있도록 구조를 변경합니다.

  ## 🔗 관련 이슈
  Closes #52

  ## 📌 변경 사항
  - [x] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [ ] 테스트
  - [ ] 기타

  ## ✅ 작업 내용
  - 매일 새벽 3시(Asia/Seoul) 실행되는 메시지 보관 스케줄러 구현
    - 1000건 청크 단위 삭제로 DB 락 방지
    - reactions → messages 순서로 FK 제약 보장
    - 신고된 메시지는 LEFT JOIN으로 삭제 대상에서 제외
  - 클라이언트 로컬 DB 동기화용 아카이브 API 추가
    - `GET /api/chat/rooms/{roomId}/messages/archive`
    - 7일 이전 메시지를 커서 기반 페이지네이션으로 제공

  ## 🧪 테스트
  - [ ] 로컬 테스트 완료

  **테스트 방법**
  1. DB에 `created_at`이 8일 이전인 메시지 INSERT 후 스케줄러 수동 실행
  2. 신고된 메시지는 삭제되지 않는지 확인
  3. `GET /api/chat/rooms/{roomId}/messages/archive` 호출 시 7일 이전 메시지만 반환되는지 확인

  ## ⚠️  주의사항
  - 클라이언트가 7일 이상 오프라인이면 해당 기간 메시지 소실 가능
  - 프론트엔드 로컬 DB 저장 및 날짜 기준 서버/로컬 분기 처리 사전 협의 필요