### PR TITLE
fix: Hibernate ddl-auto 드리프트로 인한 스키마 불일치 정리

### DIFF
--- a/src/main/resources/db/migration/V22__create_todo_table.sql
+++ b/src/main/resources/db/migration/V22__create_todo_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS todo (
+    id           BIGINT       NOT NULL AUTO_INCREMENT,
+    created_at   DATETIME(6)  DEFAULT NULL,
+    updated_at   DATETIME(6)  DEFAULT NULL,
+    content      VARCHAR(255) DEFAULT NULL,
+    date         DATE         DEFAULT NULL,
+    is_completed BIT(1)       NOT NULL,
+    user_id      BIGINT       DEFAULT NULL,
+    PRIMARY KEY (id),
+    KEY fk_todo_user (user_id),
+    CONSTRAINT fk_todo_user FOREIGN KEY (user_id) REFERENCES user (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V23__remove_duplicate_unique_key_from_user.sql
+++ b/src/main/resources/db/migration/V23__remove_duplicate_unique_key_from_user.sql
@@ -1,0 +1,15 @@
+SET @index_exists = (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user'
+      AND index_name = 'UKn4swgcf30j6bmtb4l4cjryuym'
+);
+
+SET @sql = IF(@index_exists > 0,
+    'ALTER TABLE user DROP INDEX `UKn4swgcf30j6bmtb4l4cjryuym`',
+    'SELECT 1');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/V24__fix_diary_table_columns.sql
+++ b/src/main/resources/db/migration/V24__fix_diary_table_columns.sql
@@ -1,0 +1,42 @@
+ALTER TABLE diary
+    MODIFY COLUMN character_type ENUM('GREEN', 'BROWN') NOT NULL,
+    MODIFY COLUMN emotion_type ENUM(
+        'HAPPY',
+        'ANGRY',
+        'SAD',
+        'SURPRISED',
+        'CALM',
+        'TIRED'
+    ) NOT NULL;
+
+SET @deleted_at_exists = (
+    SELECT COUNT(1)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'deleted_at'
+);
+
+SET @sql = IF(@deleted_at_exists > 0,
+    'ALTER TABLE diary DROP COLUMN deleted_at',
+    'SELECT 1');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @status_exists = (
+    SELECT COUNT(1)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'status'
+);
+
+SET @sql = IF(@status_exists > 0,
+    'ALTER TABLE diary DROP COLUMN status',
+    'SELECT 1');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## 📍 요약
`.env`의 ddl-auto 설정 충돌로 Hibernate가 Flyway 관리 밖에서 스키마를 자동 변경해온 드리프트 3건을 정식 마이그레이션으로 정리합니다.

## 🔗 관련 이슈
Closes #54

## 📌 변경 사항
- [x] 버그 수정

## ✅ 작업 내용
- V22: `todo` 테이블 생성 마이그레이션 백필 (Flyway 이력 없이 Hibernate가 자동 생성했던 것을 정식화, `CREATE TABLE IF NOT EXISTS`로 기존 환경에서도 안전)
- V23: `user` 테이블에 Hibernate가 추가한 중복 unique key(`UKn4swgcf30j6bmtb4l4cjryuym`) 제거 (information_schema 확인 후 동적 SQL로 조건부 실행, 존재하지 않는 환경에서도 안전)
- V24: `diary` 테이블을 실제 엔티티 기준(`character_type: GREEN/BROWN`, `emotion_type` 6종)으로 정정, 엔티티에 없는 `deleted_at`/`status` 컬럼 제거 (동일하게 조건부 실행)
- 운영 `.env`의 `SPRING_JPA_PROPERTIES_HIBERNATE_HBM2DDL_AUTO`를 `update`→`none`으로 수정해 재발 방지 (이 PR과 별개로 서버에 직접 적용 완료)

## 테스트
- [x] 로컬 테스트 완료
- 신규(빈) 스키마에 V1~V24 전체 순차 적용 → 정상 통과
- 기존 드리프트가 있는 로컬 DB(todo 테이블 존재, user 중복 키 존재)에 V21~V24 적용 → todo는 IF NOT EXISTS로 스킵, 중복 키는 정상 제거, diary 정상 생성 확인